### PR TITLE
{Feature} AriaViewer - add data buffering and playback speed

### DIFF
--- a/tools/visualization/AriaViewer.h
+++ b/tools/visualization/AriaViewer.h
@@ -67,10 +67,11 @@ class AriaViewer {
   pangolin::View* container_; // Pangolin window
   /// Pangolin variables
   std::unique_ptr<pangolin::Var<bool>> isPlaying_;
-  std::unique_ptr<pangolin::Var<float>> timestampSec_, temperatureDisplay_, pressureDisplay_;
+  std::unique_ptr<pangolin::Var<float>> timestampSec_, temperatureDisplay_, pressureDisplay_,
+      playbackSpeed_;
   std::unique_ptr<pangolin::Var<bool>> showLeftCamImg_, showRightCamImg_, showRgbCamImg_,
       showEyeImg_, showLeftImu_, showRightImu_, showMagnetometer_, showAudio_,
-      showNaturalImageOrientation_;
+      showNaturalImageOrientation_, showBaroTemp_;
 
   // Pangolin graphic elements
   std::map<vrs::StreamId, std::unique_ptr<pangolin::ImageView>> streamIdToPixelFrame_;


### PR DESCRIPTION
Summary:
Without data buffering, plotting functions can skip data, especially when audio is enabled.
* Adding data buffering allows the plot to display all data samples.
* Adding playback speed control from 0.01 to 10 x the playback speed.
* Add sleep_for periodic check to prevent long wait time delay on each thread.

Reviewed By: SeaOtocinclus

Differential Revision: D50467327


