### PR TITLE
{Feature} Calibration rotation - add calibration rotation by Clock wise 90 degrees

### DIFF
--- a/core/calibration/CameraCalibration.h
+++ b/core/calibration/CameraCalibration.h
@@ -20,6 +20,7 @@
 #include <string>
 
 #include <sophus/se3.hpp>
+#include <sophus/so3.hpp>
 
 #include <calibration/camera_projections/CameraProjection.h>
 
@@ -136,22 +137,30 @@ class CameraCalibration {
  * @param imageHeight Height of the camera in pixels.
  * @param focalLength Focal length of the camera in pixels.
  * @param label Label of the camera, Default value is empty string.
+ * @param T_Device_Camera Pose of the Camera Calibration (Should be the same as the original
+ * camera's pose before undistortion).
  */
 CameraCalibration getLinearCameraCalibration(
     const int imageWidth,
     const int imageHeight,
     const double focalLength,
-    const std::string& label = "");
+    const std::string& label = "",
+    const Sophus::SE3d& T_Device_Camera = Sophus::SE3d{});
 /**
  * @brief Function to create a simple Spherical camera calibration object from some parameters.
  * @param imageWidth Width of the camera in pixels.
  * @param imageHeight Height of the camera in pixels.
  * @param focalLength Focal length of the camera in pixels.
  * @param label Label of the camera, Default value is empty string.
+ * @param T_Device_Camera Pose of the Camera Calibration (Should be the same as the original
+ * camera's pose before undistortion).
  */
 CameraCalibration getSphericalCameraCalibration(
     const int imageWidth,
     const int imageHeight,
     const double focalLength,
-    const std::string& label = "");
+    const std::string& label = "",
+    const Sophus::SE3d& T_Device_Camera = Sophus::SE3d{});
+
+CameraCalibration rotateCameraCalibCW90Deg(const CameraCalibration& camCalib);
 } // namespace projectaria::tools::calibration

--- a/core/python/DeviceCalibrationPyBind.h
+++ b/core/python/DeviceCalibrationPyBind.h
@@ -173,7 +173,8 @@ inline void declareCameraCalibration(py::module& m) {
       py::arg("image_width"),
       py::arg("image_height"),
       py::arg("focal_length"),
-      py::arg("label") = "");
+      py::arg("label") = "",
+      py::arg("T_Device_Camera") = Sophus::SE3d{});
 
   m.def(
       "get_spherical_camera_calibration",
@@ -182,7 +183,14 @@ inline void declareCameraCalibration(py::module& m) {
       py::arg("image_width"),
       py::arg("image_height"),
       py::arg("focal_length"),
-      py::arg("label") = "");
+      py::arg("label") = "",
+      py::arg("T_Device_Camera") = Sophus::SE3d{});
+
+  m.def(
+      "rotate_camera_calib_cw90deg",
+      rotateCameraCalibCW90Deg,
+      "Rotate CameraCalibration (Linear model only) clock-wise for 90 degrees (Upright view)",
+      py::arg("camera_calibration"));
 }
 
 inline void declareImuCalibration(py::module& m) {


### PR DESCRIPTION
Summary:
Provide camera calibration rotation clock-wise by 90 degrees.

Code snippet
```
# input: retrieve image as a numpy array
sensor_name = "camera-rgb"
sensor_stream_id = provider.get_stream_id_from_label(sensor_name)
image_data = provider.get_image_data_by_index(sensor_stream_id, 0)
image_array = image_data[0].to_numpy_array()

# input: retrieve image distortion
device_calib = provider.get_device_calibration()
src_calib = device_calib.get_camera_calib(sensor_name)

# create output calibration: a linear model of image size 512x512 and focal length 150
# Invisible pixels are shown as black.
dst_calib = calibration.get_linear_camera_calibration(512, 512, 150, camera_name, src_calib.get_transform_device_camera())

# distort image
undistorted_rgb_image = calibration.distort_by_calibration(image_array, dst_calib, src_calib)

# Rotated image by CW90
rotated_image = np.rot90(undistorted_rgb_image, k=3)

# Get rotated image calibration
dst_calib_cw90 = calibration.rotate_camera_calib_cw90deg(dst_calib)
```

Reviewed By: PiotrBrzyski

Differential Revision: D50243089


