### PR TITLE
{Feature} Python - Add `extract_audio_track` to the projectaria_tools.core.vrs api

### DIFF
--- a/core/python/VrsPyBind.h
+++ b/core/python/VrsPyBind.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <vrs/utils/AudioTrackExtractor.h>
+#include <vrs/utils/FilteredFileReader.h>
+
+namespace projectaria::tools::vrspybind {
+
+namespace py = pybind11;
+
+namespace {
+
+inline void declareVrsAudioToWav(py::module& m) {
+  m.def(
+      "extract_audio_track",
+      [](const std::string& vrsFilePath, const std::string& wavFilePath) {
+        ::vrs::utils::FilteredFileReader filteredReader;
+        // Initialize VRS Reader and filters
+        filteredReader.setSource(vrsFilePath);
+        filteredReader.openFile();
+        filteredReader.applyFilters({});
+
+        return vrs::utils::extractAudioTrack(filteredReader, wavFilePath);
+      },
+      "Extract the audio stream of a VRS file into a WAV file");
+}
+
+} // namespace
+
+inline void exportVrs(py::module& m) {
+  declareVrsAudioToWav(m);
+}
+} // namespace projectaria::tools::vrspybind

--- a/core/python/bindings.cpp
+++ b/core/python/bindings.cpp
@@ -20,6 +20,7 @@
 #include "SensorDataPyBind.h"
 #include "StreamIdPyBind.h"
 #include "VrsDataProviderPyBind.h"
+#include "VrsPyBind.h"
 
 #include "sophus/SophusPyBind.h"
 
@@ -49,4 +50,7 @@ PYBIND11_MODULE(_core_pybinds, m) {
 
   py::module mps = m.def_submodule("mps");
   mps::exportMps(mps);
+
+  py::module vrs = m.def_submodule("vrs");
+  vrspybind::exportVrs(vrs);
 }

--- a/projectaria_tools/core/vrs.py
+++ b/projectaria_tools/core/vrs.py
@@ -12,19 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This makes the modules discoverable when doing dir(projectaria_tools.core)
-
 """
-A pybind11 binding for projectaria_tools core module
+A pybind11 binding for projectaria_tools vrs submodule
 """
 
-from . import (  # noqa
-    calibration,
-    data_provider,
-    image,
-    mps,
-    sensor_data,
-    sophus,
-    stream_id,
-    vrs,
-)
+from _core_pybinds.vrs import *  # noqa


### PR DESCRIPTION
Summary:
Extend the python API with a `projectaria_tools.core.vrs` module and a function `extract_audio_track` to extract a VRS audio stream to a `wav` sound file.

```
from projectaria_tools.core.vrs import extract_audio_track
extract_audio_track(vrs_input_file_path, wav_output_file_path)
```

Reviewed By: PiotrBrzyski

Differential Revision: D50486728


