### PR TITLE
Fix XR_CHECK condition and suppress warnings

### DIFF
--- a/core/image/ImageIterator.h
+++ b/core/image/ImageIterator.h
@@ -49,7 +49,7 @@ class ImageIterator {
     return *this;
   }
 
-  PROJECTARIA_HOST_DEVICE_INLINE ImageIterator& operator++(int) {
+  PROJECTARIA_HOST_DEVICE_INLINE ImageIterator operator++(int) {
     ImageIterator copy = *this;
     ++(*this);
     return copy;
@@ -65,7 +65,7 @@ class ImageIterator {
     return *this;
   }
 
-  PROJECTARIA_HOST_DEVICE_INLINE ImageIterator& operator--(int) {
+  PROJECTARIA_HOST_DEVICE_INLINE ImageIterator operator--(int) {
     ImageIterator copy = *this;
     --(*this);
     return copy;

--- a/core/mps/StaticCameraCalibrationReader.cpp
+++ b/core/mps/StaticCameraCalibrationReader.cpp
@@ -90,7 +90,7 @@ StaticCameraCalibrations readStaticCameraCalibrations(const std::string& fileNam
     pose.intrinsics = intrinsics;
 
     XR_CHECK(
-        (start_frame_idx == -1 && start_frame_idx == -1) ||
+        (start_frame_idx == -1 && end_frame_idx == -1) ||
             (start_frame_idx >= 0 && end_frame_idx >= 0 && start_frame_idx <= end_frame_idx),
         "start and end frame indices are invalid");
     if (start_frame_idx >= 0) {

--- a/core/mps/StaticCameraCalibrationReader.cpp
+++ b/core/mps/StaticCameraCalibrationReader.cpp
@@ -90,7 +90,6 @@ StaticCameraCalibrations readStaticCameraCalibrations(const std::string& fileNam
     pose.intrinsics = intrinsics;
 
     XR_CHECK(
-        (start_frame_idx == -1 && end_frame_idx == -1) ||
             (start_frame_idx >= 0 && end_frame_idx >= 0 && start_frame_idx <= end_frame_idx),
         "start and end frame indices are invalid");
     if (start_frame_idx >= 0) {

--- a/tools/visualization/AriaViewer.cpp
+++ b/tools/visualization/AriaViewer.cpp
@@ -180,7 +180,6 @@ void AriaViewer::addImuDisplays(std::shared_ptr<VrsDataProvider> dataProvider) {
     auto streamId = *dataProvider->getStreamIdFromLabel(label);
 
     streamIdToMultiDataLog_[streamId] = std::vector<std::shared_ptr<pangolin::DataLog>>(2, nullptr);
-    streamIdToMultiDataLog_[streamId] = std::vector<std::shared_ptr<pangolin::DataLog>>(2, nullptr);
 
     streamIdToMultiDataLog_.at(streamId).at(0) = std::make_shared<pangolin::DataLog>();
     streamIdToMultiDataLog_.at(streamId).at(0)->SetLabels(


### PR DESCRIPTION
- Fix [XR_CHECK's first condition](https://github.com/facebookresearch/projectaria_tools/blob/ac6997378bf09d9cf4114105fa1fe023dad209e7/core/mps/StaticCameraCalibrationReader.cpp#L92) to ensure both `start_frame_idx` and `end_frame_idx` are valid.
- Removed [duplicated instruction](https://github.com/facebookresearch/projectaria_tools/blob/ac6997378bf09d9cf4114105fa1fe023dad209e7/tools/visualization/AriaViewer.cpp#L182)
- Suppress warning: [Reference to local variable returned](https://github.com/facebookresearch/projectaria_tools/blob/ac6997378bf09d9cf4114105fa1fe023dad209e7/core/image/ImageIterator.h#L52C7-L52C7)