### PR TITLE
{Feature} Sample - GlobalPointCloud colorization

### DIFF
--- a/core/mps/CMakeLists.txt
+++ b/core/mps/CMakeLists.txt
@@ -26,11 +26,13 @@ target_include_directories(eye_gaze
 )
 
 add_library(mps
+    CachedDataProviders.h
     OnlineCalibration.h
     OnlineCalibrationFormat.h
     onlineCalibrationReader.h onlineCalibrationReader.cpp
     GlobalPointCloud.h
     GlobalPointCloudFormat.h
+    GlobalPointCloudFilter.h
     GlobalPointCloudReader.h GlobalPointCloudReader.cpp
     PointObservation.h
     PointObservationFormat.h

--- a/core/mps/GlobalPointCloudFilter.h
+++ b/core/mps/GlobalPointCloudFilter.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "GlobalPointCloud.h"
+
+#include <iostream>
+#include <vector>
+
+namespace projectaria::tools::mps {
+
+/// Filter a GlobalPointCloud given threshold for
+///  - inverse distance standard deviation
+///  - standard deviation of the distance estimate
+inline GlobalPointCloud filterPointsFromConfidence(
+    const GlobalPointCloud& in,
+    const float threshold_invdep = 0.001,
+    const float threshold_dep = 0.05) {
+  GlobalPointCloud out;
+  out.reserve(in.size());
+
+  for (const auto& point : in) {
+    if (point.inverseDistanceStd > threshold_invdep) {
+      continue;
+    }
+    if (point.distanceStd > threshold_dep) {
+      continue;
+    }
+    out.emplace_back(point);
+  }
+  out.shrink_to_fit();
+  std::cout << "PointCloud filtering:\n"
+            << " - kept: " << out.size() << " points \n"
+            << " - kept: " << 100 * out.size() / static_cast<float>(in.size() + 1) << " %"
+            << " of the original size" << std::endl;
+  return out;
+}
+
+} // namespace projectaria::tools::mps

--- a/tools/mps_visualization/CMakeLists.txt
+++ b/tools/mps_visualization/CMakeLists.txt
@@ -44,7 +44,7 @@ message("--- Compiling mps_3d_replay_viewer.")
 add_executable(mps_3d_replay_viewer
     main_3d_replay_viewer.cpp
     Data3DGui.cpp Data3DGui.h
-    Boundary.h CachedDataProviders.h
+    Boundary.h
     PangolinHelper.h
 )
 target_link_libraries(mps_3d_replay_viewer

--- a/tools/samples/CMakeLists.txt
+++ b/tools/samples/CMakeLists.txt
@@ -12,13 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-find_package(Pangolin QUIET)
-if (Pangolin_FOUND)
-    find_package(Threads REQUIRED)
-    add_subdirectory(visualization)
-    add_subdirectory(mps_visualization)
-else()
-    message("Pangolin has not been found. Visualization tools will not be compiled.")
-endif()
-
-add_subdirectory(samples)
+message("--- Compiling samples.")
+add_subdirectory(pointcloud_colorization)

--- a/tools/samples/pointcloud_colorization/CMakeLists.txt
+++ b/tools/samples/pointcloud_colorization/CMakeLists.txt
@@ -12,13 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-find_package(Pangolin QUIET)
-if (Pangolin_FOUND)
-    find_package(Threads REQUIRED)
-    add_subdirectory(visualization)
-    add_subdirectory(mps_visualization)
-else()
-    message("Pangolin has not been found. Visualization tools will not be compiled.")
-endif()
+find_package(Boost REQUIRED)
 
-add_subdirectory(samples)
+message("--- Compiling mps_point_cloud_colorization.")
+add_executable(mps_point_cloud_colorization
+    main_PointCloudColorization.cpp
+    GlobalPointCloudToPly.h
+    PointCloudColorizer.h
+    SLAMPointCloudColorizer.h
+    RGBPointCloudColorizer.h)
+
+target_link_libraries(mps_point_cloud_colorization
+    PRIVATE
+        CLI11::CLI11
+        ${Boost_LIBRARIES}
+        mps
+        vrs_data_provider)

--- a/tools/samples/pointcloud_colorization/GlobalPointCloudToPly.h
+++ b/tools/samples/pointcloud_colorization/GlobalPointCloudToPly.h
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include "GlobalPointCloud.h"
+
+namespace {
+
+/// Export GlobalPointCloud 3D points to PLY format
+template <class T>
+inline bool exportToPly(
+    const projectaria::tools::mps::GlobalPointCloud& points,
+    const std::string& filename,
+    const std::optional<T>& colors = std::nullopt);
+
+template <>
+inline bool exportToPly(
+    const projectaria::tools::mps::GlobalPointCloud& points,
+    const std::string& filename,
+    const std::optional<std::vector<float>>& colors) {
+  std::ofstream outfile(filename.c_str());
+  if (!outfile) {
+    return false;
+  }
+
+  outfile << "ply" << '\n'
+          << "format ascii 1.0" << '\n'
+          << "element vertex " << points.size() << '\n'
+          << "property double x" << '\n'
+          << "property double y" << '\n'
+          << "property double z" << '\n'
+          << "property uchar red" << '\n'
+          << "property uchar green" << '\n'
+          << "property uchar blue" << '\n'
+          << "end_header"
+          << "\n";
+
+  outfile << std::fixed << std::setprecision(std::numeric_limits<double>::digits10 + 1);
+
+  for (size_t i = 0; i < points.size(); ++i) {
+    if (colors) {
+      outfile << points[i].position_world.x() << ' ' << points[i].position_world.y() << ' '
+              << points[i].position_world.z() << ' ' << static_cast<int>((*colors)[i]) << ' '
+              << static_cast<int>((*colors)[i]) << ' ' << static_cast<int>((*colors)[i]) << "\n";
+    } else {
+      // We dont have any colors so we just set them all to white
+      outfile << points[i].position_world.x() << ' ' << points[i].position_world.y() << ' '
+              << points[i].position_world.z() << ' ' << "255 255 255\n";
+    }
+  }
+
+  outfile.flush();
+  const bool bOk = outfile.good();
+  outfile.close();
+  return bOk;
+}
+
+/// Export 3D point vector and color to PLY format
+template <>
+inline bool exportToPly(
+    const projectaria::tools::mps::GlobalPointCloud& points,
+    const std::string& filename,
+    const std::optional<std::vector<Eigen::Vector3f>>& colors) {
+  std::ofstream outfile(filename.c_str());
+  if (!outfile) {
+    return false;
+  }
+
+  outfile << "ply" << '\n'
+          << "format ascii 1.0" << '\n'
+          << "element vertex " << points.size() << '\n'
+          << "property double x" << '\n'
+          << "property double y" << '\n'
+          << "property double z" << '\n'
+          << "property uchar red" << '\n'
+          << "property uchar green" << '\n'
+          << "property uchar blue" << '\n'
+          << "end_header"
+          << "\n";
+
+  outfile << std::fixed << std::setprecision(std::numeric_limits<double>::digits10 + 1);
+
+  for (size_t i = 0; i < points.size(); ++i) {
+    if (colors) {
+      outfile << points[i].position_world.x() << ' ' << points[i].position_world.y() << ' '
+              << points[i].position_world.z() << ' ' << static_cast<int>((*colors)[i].x()) << ' '
+              << static_cast<int>((*colors)[i].y()) << ' ' << static_cast<int>((*colors)[i].z())
+              << "\n";
+    } else {
+      // We dont have any colors so we just set them all to white
+      outfile << points[i].position_world.x() << ' ' << points[i].position_world.y() << ' '
+              << points[i].position_world.z() << ' ' << "255 255 255\n";
+    }
+  }
+
+  outfile.flush();
+  const bool bOk = outfile.good();
+  outfile.close();
+  return bOk;
+}
+
+} // namespace

--- a/tools/samples/pointcloud_colorization/PointCloudColorizer.h
+++ b/tools/samples/pointcloud_colorization/PointCloudColorizer.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "GlobalPointCloud.h"
+#include "PointObservation.h"
+#include "Trajectory.h"
+
+#include <data_provider/VrsDataProvider.h>
+
+#include <vector>
+
+namespace {
+// Generic Abstract base class for all GlobalPointCloud colorizers
+class PointCloudColorizer {
+ public:
+  explicit PointCloudColorizer(
+      const projectaria::tools::mps::ClosedLoopTrajectory& trajectory,
+      const projectaria::tools::mps::GlobalPointCloud& globalPointCloud,
+      const projectaria::tools::mps::PointObservations& pointObservations,
+      std::shared_ptr<projectaria::tools::data_provider::VrsDataProvider> dataProvider)
+      : globalPointCloud_(globalPointCloud),
+        trajectory_(trajectory),
+        pointObservations_(pointObservations),
+        dataProvider_(dataProvider) {}
+
+  virtual ~PointCloudColorizer() = default;
+
+  /// Main colorize function (must compute a color (gray or RGB) for all possible point in
+  /// GlobalPointCloud)
+  virtual void Colorize() = 0;
+
+  /// Return gray colors in range [0, 255]
+  /// @return empty optional if no gray colorization
+  virtual std::optional<std::vector<float>> getGray() {
+    return {};
+  }
+
+  /// Return RGB colors in range [0, 255]
+  /// @return empty optional if no RGB colorization
+  virtual std::optional<std::vector<Eigen::Vector3f>> getRGB() {
+    return {};
+  }
+
+ protected:
+  const projectaria::tools::mps::GlobalPointCloud& globalPointCloud_;
+  const projectaria::tools::mps::ClosedLoopTrajectory& trajectory_;
+  const projectaria::tools::mps::PointObservations& pointObservations_;
+  std::shared_ptr<projectaria::tools::data_provider::VrsDataProvider> dataProvider_;
+};
+} // namespace

--- a/tools/samples/pointcloud_colorization/RGBPointCloudColorizer.h
+++ b/tools/samples/pointcloud_colorization/RGBPointCloudColorizer.h
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "AriaStreamIds.h"
+#include "CachedDataProviders.h"
+#include "PointCloudColorizer.h"
+
+#include <boost/timer/progress_display.hpp>
+#include <unordered_map>
+
+namespace {
+
+// Colorize a GlobalPointCloud given its RGB and SLAM image observations.
+//
+// This implementation does not target speed, but being used as a tutorial
+//
+class RGBPointCloudColorizer : public PointCloudColorizer {
+ public:
+  bool rgbOnly_ = false; // Tell if we are using or rejecting the SLAM images
+
+  // Color accumulator (for each point uid, accumulate normalized RGB color [0.f, 1.f])
+  std::unordered_map<uint32_t, Eigen::Vector3f> colorAccumulator_;
+  // Accumulator count (Keep track of visited point to know how many pixel observations has been
+  // accumulated)
+  std::unordered_map<uint32_t, uint32_t> accumulatorCount_;
+
+  explicit RGBPointCloudColorizer(
+      const projectaria::tools::mps::ClosedLoopTrajectory& trajectory,
+      const projectaria::tools::mps::GlobalPointCloud& globalPointCloud,
+      const projectaria::tools::mps::PointObservations& pointObservations,
+      std::shared_ptr<projectaria::tools::data_provider::VrsDataProvider> dataProvider,
+      bool rgbOnly = false)
+      : PointCloudColorizer(trajectory, globalPointCloud, pointObservations, dataProvider),
+        rgbOnly_(rgbOnly) {}
+
+  ~RGBPointCloudColorizer() override = default;
+
+  void Colorize() override {
+    using namespace projectaria::tools::data_provider;
+    using namespace projectaria::tools::image;
+    using namespace projectaria::tools::mps;
+
+    colorAccumulator_.clear();
+    accumulatorCount_.clear();
+
+    const size_t numRgbData = dataProvider_->getNumData(kRgbCameraStreamId);
+    const int64_t startTimestampNs = dataProvider_->getFirstTimeNs(kRgbCameraStreamId);
+    const int64_t endTimestampNs = dataProvider_->getLastTimeNs(kRgbCameraStreamId);
+
+    const auto leftCameraSerial =
+        dataProvider_->getImageConfiguration(kSlamLeftCameraStreamId).sensorSerial;
+    const auto rightCameraSerial =
+        dataProvider_->getImageConfiguration(kSlamRightCameraStreamId).sensorSerial;
+
+    // Cache point observations (group by timestamp)
+    PointAndObservationProvider pointObsProvider(
+        globalPointCloud_,
+        pointObservations_,
+        leftCameraSerial,
+        rightCameraSerial,
+        startTimestampNs,
+        endTimestampNs);
+    std::cout << "Point observations cache:\n"
+              << " - #left frames: " << pointObsProvider.numObsFrameLeft() << "\n"
+              << " - #right frames: " << pointObsProvider.numObsFrameRight() << "\n"
+              << " - #point cache size: " << pointObsProvider.numPointObs() << std::endl;
+
+    TrajectoryProvider trajectoryProvider(trajectory_, startTimestampNs, endTimestampNs);
+
+    // Loop through the frames and color the points cloud
+    {
+      boost::timer::progress_display progressBar(
+          numRgbData, std::cout, "Looping over VRS image frames and PointCloud observations.\n");
+      for (int64_t frameId = 0; frameId < numRgbData; ++frameId) {
+        ++progressBar;
+
+        //
+        // Organize data as [RGB, SLAM LEFT, SLAM RIGHT] arrays and loop over the point observations
+        //
+
+        // Get RGB camera image
+        std::vector<ImageDataAndRecord> imageDataAndRecord{
+            dataProvider_->getImageDataByIndex(kRgbCameraStreamId, frameId)};
+
+        // Get current timestamp
+        const int64_t captureTimestampNs = imageDataAndRecord[0].second.captureTimestampNs;
+
+        // Append closest time SLAM images
+        imageDataAndRecord.push_back(
+            dataProvider_->getImageDataByTimeNs(kSlamLeftCameraStreamId, captureTimestampNs));
+        imageDataAndRecord.push_back(
+            dataProvider_->getImageDataByTimeNs(kSlamRightCameraStreamId, captureTimestampNs));
+
+        // Get current pose from cached trajectory
+        const auto pose = trajectoryProvider.findPose(captureTimestampNs);
+        if (!pose) {
+          continue;
+        }
+
+        const std::array<projectaria::tools::calibration::CameraCalibration, 3> cameras{
+            *dataProvider_->getDeviceCalibration()->getCameraCalib("camera-rgb"),
+            *dataProvider_->getDeviceCalibration()->getCameraCalib("camera-slam-left"),
+            *dataProvider_->getDeviceCalibration()->getCameraCalib("camera-slam-right")};
+
+        std::vector<std::vector<PointObservationPair>> currentFramePointObservations;
+        currentFramePointObservations.push_back(
+            pointObsProvider.findAllPointObs(leftCameraSerial, captureTimestampNs));
+        currentFramePointObservations.push_back(
+            pointObsProvider.findAllPointObs(rightCameraSerial, captureTimestampNs));
+
+        // For all observations:
+        // - try to re-project 3D point to RGB camera
+        //   - if valid reprojection -> sample from RGB image, else sample for SLAM images
+        // Note: It is not guaranteed that all 3D point can be projected in RGB images
+        for (const auto& observations : currentFramePointObservations) {
+          for (const auto& ptIt : observations) {
+            const auto ptUid = ptIt.second.uid;
+
+            for (const int index : {0, 1, 2}) // RGB, SLAM LEFT, SLAM RIGHT
+            {
+              // Use Point Projection
+              const auto T_Device_camera = cameras[index].getT_Device_Camera();
+
+              // Retrieve corresponding World Point
+              const auto position_world = ptIt.second.position_world;
+              const auto T_world_cam = pose->T_world_device * T_Device_camera;
+              const auto position_local = T_world_cam.inverse() * position_world;
+
+              const auto projection = cameras[index].project(position_local);
+              if (!projection) {
+                // 3D point is not visible, continue to next image
+                continue;
+              }
+              Eigen::Vector2f uv = projection->cast<float>();
+
+              // Color sampling
+              if (index == 0) { // RGB image
+                const Image3U8 image =
+                    std::get<Image3U8>(imageDataAndRecord[index].first.imageVariant().value());
+                const auto pixValue = image(uv.x(), uv.y());
+                if (colorAccumulator_.count(ptUid) == 0) {
+                  colorAccumulator_[ptUid] =
+                      Eigen::Vector3f(pixValue.x(), pixValue.y(), pixValue.z()) / 255.f;
+                  accumulatorCount_[ptUid] = 1;
+                } else {
+                  colorAccumulator_.at(ptUid) +=
+                      Eigen::Vector3f(pixValue.x(), pixValue.y(), pixValue.z()) / 255.f;
+                  ++accumulatorCount_.at(ptUid);
+                }
+              } else { // SLAM image
+                const ImageU8 image =
+                    std::get<ImageU8>(imageDataAndRecord[index].first.imageVariant().value());
+                const float pixValue = static_cast<float>(image(uv.x(), uv.y())) / 255.f;
+                const Eigen::Vector3f color{pixValue, pixValue, pixValue};
+                if (colorAccumulator_.count(ptUid) == 0) {
+                  colorAccumulator_[ptUid] = color;
+                  accumulatorCount_[ptUid] = 1;
+                } else {
+                  colorAccumulator_.at(ptUid) += color;
+                  ++accumulatorCount_.at(ptUid);
+                }
+              }
+
+              break; // We already sampled the point color, no need to check another image
+            }
+          }
+        }
+      }
+    }
+  }
+
+  /// Return RGB colors in range [0, 255]
+  std::optional<std::vector<Eigen::Vector3f>> getRGB() override {
+    assert(globalPointCloud_.size() == accumulatorCount_.size());
+    assert(accumulatorCount_.size() == colorAccumulator_.size());
+    // Normalize colors
+    std::vector<Eigen::Vector3f> colors;
+    colors.reserve(globalPointCloud_.size());
+    for (const auto& pt : globalPointCloud_) {
+      if (accumulatorCount_.count(pt.uid) == 0) {
+        // If point has been unseen set a default color
+        colors.push_back(Eigen::Vector3f(255, 0, 0) / 255.f);
+        continue;
+      }
+      colors.push_back(colorAccumulator_.at(pt.uid));
+      // Normalize the color
+      colors.back() /= accumulatorCount_.at(pt.uid);
+      colors.back() *= 255;
+    }
+    return colors;
+  }
+};
+
+} // namespace

--- a/tools/samples/pointcloud_colorization/SLAMPointCloudColorizer.h
+++ b/tools/samples/pointcloud_colorization/SLAMPointCloudColorizer.h
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "AriaStreamIds.h"
+#include "CachedDataProviders.h"
+#include "PointCloudColorizer.h"
+
+#include <boost/timer/progress_display.hpp>
+#include <unordered_map>
+
+namespace {
+// Colorize a GlobalPointCloud given its SLAM image observations.
+// Colorization could be done:
+// - using the existing stored image observations (u,v) (FAST)
+// - or by projecting the 3D points to the SLAM images (SLOWER)
+//
+// This implementation does not target speed, but being used as a tutorial
+//
+class SLAMPointCloudColorizer : public PointCloudColorizer {
+ public:
+  bool useProjectedPoints_ = false; // Tell if we are using Projected 3D points or using the
+                                    // existing (u,v) point coordinates
+
+  // Color accumulator (for each point uid, accumulate normalized color [0.f, 1.f])
+  std::unordered_map<uint32_t, float> colorAccumulator_;
+  // Accumulator count (Keep track of visited point to know how many pixel observations has been
+  // accumulated)
+  std::unordered_map<uint32_t, uint32_t> accumulatorCount_;
+
+  explicit SLAMPointCloudColorizer(
+      const projectaria::tools::mps::ClosedLoopTrajectory& trajectory,
+      const projectaria::tools::mps::GlobalPointCloud& globalPointCloud,
+      const projectaria::tools::mps::PointObservations& pointObservations,
+      std::shared_ptr<projectaria::tools::data_provider::VrsDataProvider> dataProvider,
+      bool useProjectedPoints = false)
+      : PointCloudColorizer(trajectory, globalPointCloud, pointObservations, dataProvider),
+        useProjectedPoints_(useProjectedPoints) {}
+
+  ~SLAMPointCloudColorizer() override = default;
+
+  void Colorize() override {
+    using namespace projectaria::tools::data_provider;
+    using namespace projectaria::tools::image;
+    using namespace projectaria::tools::mps;
+
+    colorAccumulator_.clear();
+    accumulatorCount_.clear();
+
+    const size_t numSlamData = dataProvider_->getNumData(kSlamLeftCameraStreamId);
+    const int64_t startTimestampNs = dataProvider_->getFirstTimeNs(kSlamLeftCameraStreamId);
+    const int64_t endTimestampNs = dataProvider_->getLastTimeNs(kSlamLeftCameraStreamId);
+
+    const auto leftCameraSerial =
+        dataProvider_->getImageConfiguration(kSlamLeftCameraStreamId).sensorSerial;
+    const auto rightCameraSerial =
+        dataProvider_->getImageConfiguration(kSlamRightCameraStreamId).sensorSerial;
+
+    // Cache point observations (group by timestamp)
+    PointAndObservationProvider pointObsProvider(
+        globalPointCloud_,
+        pointObservations_,
+        leftCameraSerial,
+        rightCameraSerial,
+        startTimestampNs,
+        endTimestampNs);
+    std::cout << "Point observations cache:\n"
+              << " - #left frames: " << pointObsProvider.numObsFrameLeft() << "\n"
+              << " - #right frames: " << pointObsProvider.numObsFrameRight() << "\n"
+              << " - #point cache size: " << pointObsProvider.numPointObs() << std::endl;
+
+    TrajectoryProvider trajectoryProvider(trajectory_, startTimestampNs, endTimestampNs);
+
+    // Loop through the frames and color the points cloud
+    {
+      boost::timer::progress_display progressBar(
+          numSlamData, std::cout, "Looping over VRS image frames and PointCloud observations.\n");
+      for (int64_t frameId = 0; frameId < numSlamData; ++frameId) {
+        ++progressBar;
+
+        //
+        // Organize data as [LEFT, RIGHT] array and loop over the point observations
+        //
+
+        // Get SLAM camera images
+        const std::array<ImageDataAndRecord, 2> imageDataAndRecord{
+            dataProvider_->getImageDataByIndex(kSlamLeftCameraStreamId, frameId),
+            dataProvider_->getImageDataByIndex(kSlamRightCameraStreamId, frameId)};
+
+        // Get current timestamp
+        const int64_t captureTimestampNs = imageDataAndRecord[0].second.captureTimestampNs;
+
+        // Get current pose from cached trajectory
+        const auto pose = trajectoryProvider.findPose(captureTimestampNs);
+        if (!pose) {
+          continue;
+        }
+
+        const std::array<ImageU8, 2> images{
+            std::get<ImageU8>(imageDataAndRecord[0].first.imageVariant().value()),
+            std::get<ImageU8>(imageDataAndRecord[1].first.imageVariant().value())};
+
+        const std::array<projectaria::tools::calibration::CameraCalibration, 2> cameras{
+            *dataProvider_->getDeviceCalibration()->getCameraCalib("camera-slam-left"),
+            *dataProvider_->getDeviceCalibration()->getCameraCalib("camera-slam-right")};
+
+        const std::array<std::vector<PointObservationPair>, 2> currentFramePointObservations{
+            pointObsProvider.findAllPointObs(leftCameraSerial, captureTimestampNs),
+            pointObsProvider.findAllPointObs(rightCameraSerial, captureTimestampNs)};
+
+        // Sample GRAY VRS image colors from the LEFT and RIGHT point observations
+        for (const int index : {0, 1}) {
+          const auto& currentFrameObservations = currentFramePointObservations[index];
+
+          Eigen::Vector2f uv;
+          for (const auto& ptIt : currentFrameObservations) {
+            const auto ptUid = ptIt.second.uid;
+
+            if (useProjectedPoints_) {
+              // Use Point Projection
+              const auto T_Device_camera = cameras[index].getT_Device_Camera();
+
+              // Retrieve corresponding World Point
+              const auto position_world = ptIt.second.position_world;
+              const auto T_world_cam = pose->T_world_device * T_Device_camera;
+              const auto position_local = T_world_cam.inverse() * position_world;
+
+              const auto projection = cameras[index].project(position_local);
+              if (!projection) {
+                // 3D point is not visible
+                continue;
+              }
+              uv = projection->cast<float>();
+            } else {
+              // Directly use the feature coordinate
+              uv = ptIt.first;
+            }
+
+            // Color sampling
+            const auto& image = images[index];
+            if (colorAccumulator_.count(ptUid) == 0) {
+              colorAccumulator_[ptUid] = (image(uv.x(), uv.y()) / 255.f);
+              accumulatorCount_[ptUid] = 1;
+            } else {
+              colorAccumulator_.at(ptUid) += (image(uv.x(), uv.y()) / 255.f);
+              ++accumulatorCount_.at(ptUid);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  /// Return gray colors in range [0, 255]
+  std::optional<std::vector<float>> getGray() override {
+    assert(globalPointCloud_.size() == accumulatorCount_.size());
+    assert(accumulatorCount_.size() == colorAccumulator_.size());
+    // Normalize colors
+    std::vector<float> colors;
+    colors.reserve(globalPointCloud_.size());
+    for (const auto& pt : globalPointCloud_) {
+      if (accumulatorCount_.count(pt.uid) == 0) {
+        // If point has been unseen set a default color
+        colors.push_back(0.f);
+        continue;
+      }
+      colors.push_back(colorAccumulator_.at(pt.uid));
+      // Normalize the color
+      colors.back() /= accumulatorCount_.at(pt.uid);
+      colors.back() *= 255;
+    }
+    return colors;
+  }
+};
+} // namespace

--- a/tools/samples/pointcloud_colorization/main_PointCloudColorization.cpp
+++ b/tools/samples/pointcloud_colorization/main_PointCloudColorization.cpp
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "AriaStreamIds.h"
+#include "GlobalPointCloudFilter.h"
+#include "GlobalPointCloudReader.h"
+#include "PointObservationReader.h"
+#include "TrajectoryReaders.h"
+
+#include <data_provider/VrsDataProvider.h>
+
+#include <CLI/CLI.hpp>
+
+#include <cstdint>
+#include <filesystem>
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "GlobalPointCloudToPly.h"
+#include "RGBPointCloudColorizer.h"
+#include "SLAMPointCloudColorizer.h"
+
+using namespace projectaria::tools;
+using namespace projectaria::tools::data_provider;
+using namespace projectaria::tools::image;
+using namespace projectaria::tools::mps;
+
+int main(int argc, const char* argv[]) {
+  std::string closedLoopTrajPath;
+  std::string globalPointCloudPath;
+  std::string globalPointObservationPath;
+  std::string vrsPath;
+  bool doNotFilter = false;
+  bool useProjectionForGrayColoring = false;
+
+  CLI::App app{"Point Cloud Colorization samples"};
+
+  app.add_option(
+         "--closed-loop-traj", closedLoopTrajPath, "Input closed loop trajectory file path.")
+      ->check(CLI::ExistingPath)
+      ->required();
+  app.add_option(
+         "--global-point-cloud", globalPointCloudPath, "Input global point cloud file path.")
+      ->check(CLI::ExistingPath)
+      ->required();
+  app.add_option(
+         "--global-point-cloud-observations",
+         globalPointObservationPath,
+         "Input global point cloud observations.")
+      ->check(CLI::ExistingPath)
+      ->required();
+  app.add_option("--vrs", vrsPath, "Input vrs file.")->check(CLI::ExistingPath)->required();
+  app.add_flag(
+      "--use-projection-for-gray-coloring",
+      useProjectionForGrayColoring,
+      "By default GRAY coloring is using stored (u,v) feature coordinates since it is faster,\n"
+      "this options allows you to use 3D point projection instead.");
+  app.add_flag("--do-not-filter", doNotFilter, "Do not filter point cloud");
+
+  CLI11_PARSE(app, argc, argv);
+
+  // Load closed loop trajectories
+  const auto trajectory = readClosedLoopTrajectory(closedLoopTrajPath);
+
+  // Load point cloud (can be .csv or .gz)
+  auto ptCloud = readGlobalPointCloud(globalPointCloudPath);
+
+  auto pointObservations = readPointObservations(globalPointObservationPath);
+
+  // Open the VRS File
+  auto dataProvider = data_provider::createVrsDataProvider(vrsPath);
+
+  if (!doNotFilter) {
+    ptCloud = filterPointsFromConfidence(ptCloud);
+  }
+
+  // SLAM based image colorization
+  {
+    std::cout << "-- Perform SLAM based image point cloud colorization --" << std::endl;
+    SLAMPointCloudColorizer pointCloudColorizer(
+        trajectory, ptCloud, pointObservations, dataProvider, useProjectionForGrayColoring);
+    pointCloudColorizer.Colorize();
+    std::cout << "Saving PLY file." << std::endl;
+    exportToPly(ptCloud, "gray.ply", pointCloudColorizer.getGray());
+  }
+
+  // RGB, SLAM based image colorization
+  {
+    std::cout << "-- Perform RGB based image point cloud colorization --" << std::endl;
+    RGBPointCloudColorizer pointCloudColorizer(
+        trajectory, ptCloud, pointObservations, dataProvider);
+    pointCloudColorizer.Colorize();
+    std::cout << "Saving PLY file." << std::endl;
+    exportToPly(ptCloud, "rgb.ply", pointCloudColorizer.getRGB());
+  }
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Summary:
Add a sample to show how to colorize a GlobalPointCloud:
- Using the SLAM images
  - with pre-stored image feature location (u,v)
  - with 3d point projection

- Using the RGB and SLAM images
  - Since all 3D features are not visible in the RGB images, we need to fall back to SLAM images for colorization

Observed colors are accumulated and normalized (mean).

How to use it:
```
mkdir build
cd build
cmake ../projectaria_tools/ -DPROJECTARIA_TOOLS_BUILD_TOOLS=ON

./tools/samples/pointcloud_colorization/mps_point_cloud_colorization --closed-loop-traj '<PATH>/closed_loop_trajectory.csv' --global-point-cloud '<PATH>/global_points.csv.gz' --global-point-cloud-observations '<PATH>/semidense_observations.csv.gz' --vrs '<PATH>/file.vrs'
```

Differential Revision: D51670287


