### PR TITLE
{Build} Improve FMT compatibility

### DIFF
--- a/core/calibration/CameraCalibrationFormat.h
+++ b/core/calibration/CameraCalibrationFormat.h
@@ -16,23 +16,21 @@
 
 #pragma once
 
-#include <fmt/format.h>
-#include <format/Format.h>
 #include "CameraCalibration.h"
 #include "camera_projections/CameraProjectionFormat.h"
+#include "format/Format.h"
 
 /*
  * fmt::format() specialization for CameraCalibration
  */
 template <>
-struct fmt::formatter<projectaria::tools::calibration::CameraCalibration> {
-  // No parse function needed
-
-  // Format the Point object
+struct fmt::formatter<projectaria::tools::calibration::CameraCalibration>
+    : fmt::formatter<std::string_view> {
+  // Format the CameraCalibration object
   template <typename FormatContext>
   auto format(
       const projectaria::tools::calibration::CameraCalibration& camCalib,
-      FormatContext& ctx) {
+      FormatContext& ctx) const {
     return format_to(
         ctx.out(),
         "CameraCalibration(label: {}, model name: {}, principal point: {}, focal length: {}, projection params: {}, image size (w,h): {}, T_Device_Camera:{}, serialNumber:{})",

--- a/core/calibration/ImuMagnetometerCalibrationFormat.h
+++ b/core/calibration/ImuMagnetometerCalibrationFormat.h
@@ -16,20 +16,19 @@
 
 #pragma once
 
-#include <fmt/format.h>
-#include <format/Format.h>
 #include "ImuMagnetometerCalibration.h"
+#include "format/Format.h"
 
 /*
  * fmt::format() specialization for IMUCalibration
  */
 template <>
-struct fmt::formatter<projectaria::tools::calibration::ImuCalibration> {
-  // No parse function needed
-
-  // Format the ImuCalibrattion object
+struct fmt::formatter<projectaria::tools::calibration::ImuCalibration>
+    : fmt::formatter<std::string_view> {
+  // Format the ImuCalibration object
   template <typename FormatContext>
-  auto format(const projectaria::tools::calibration::ImuCalibration& imuCalib, FormatContext& ctx) {
+  auto format(const projectaria::tools::calibration::ImuCalibration& imuCalib, FormatContext& ctx)
+      const {
     return format_to(
         ctx.out(),
         "ImuCalibration(label: {}, T_Device_Imu: {})",

--- a/core/format/Format.h
+++ b/core/format/Format.h
@@ -22,17 +22,13 @@
  * fmt::format() specialization for Eigen Matrix
  */
 template <typename SCALAR, int ROWS, int COLS, int Options, int MaxRows, int MaxCols>
-struct fmt::formatter<Eigen::Matrix<SCALAR, ROWS, COLS, Options, MaxRows, MaxCols>> {
-  // Need to define this function ourselves for partial specialization
-  constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator {
-    return ctx.begin();
-  }
-
+struct fmt::formatter<Eigen::Matrix<SCALAR, ROWS, COLS, Options, MaxRows, MaxCols>>
+    : fmt::formatter<std::string_view> {
   // Format the Eigen::Matrix object
   template <typename FormatContext>
   auto format(
       const Eigen::Matrix<SCALAR, ROWS, COLS, Options, MaxRows, MaxCols>& mat,
-      FormatContext& ctx) {
+      FormatContext& ctx) const {
     std::stringstream ss;
     if constexpr (COLS == 1) {
       ss << mat.format(kVectorFormat);
@@ -69,15 +65,10 @@ struct fmt::formatter<Eigen::Matrix<SCALAR, ROWS, COLS, Options, MaxRows, MaxCol
  * fmt::format() specialization for Sophus SE3
  */
 template <typename SCALAR>
-struct fmt::formatter<Sophus::SE3<SCALAR>> {
-  // Default parse implementation
-  auto parse(format_parse_context& ctx) {
-    return ctx.begin();
-  }
-
+struct fmt::formatter<Sophus::SE3<SCALAR>> : fmt::formatter<std::string_view> {
   // Format the Sophus::SE3 object
   template <typename FormatContext>
-  auto format(const Sophus::SE3<SCALAR>& se3, FormatContext& ctx) {
+  auto format(const Sophus::SE3<SCALAR>& se3, FormatContext& ctx) const {
     return format_to(
         ctx.out(),
         "(translation:{}, quaternion(x,y,z,w):{})",

--- a/core/mps/EyeGazeFormat.h
+++ b/core/mps/EyeGazeFormat.h
@@ -17,18 +17,17 @@
 #pragma once
 #include <fmt/chrono.h>
 #include <fmt/format.h>
+
 #include "EyeGaze.h"
 
 /*
  * fmt::format() specialization for EyeGaze
  */
 template <>
-struct fmt::formatter<projectaria::tools::mps::EyeGaze> {
-  // No parse function needed
-
-  // Format the Point object
+struct fmt::formatter<projectaria::tools::mps::EyeGaze> : fmt::formatter<std::string_view> {
+  // Format the EyeGaze object
   template <typename FormatContext>
-  auto format(const projectaria::tools::mps::EyeGaze& gaze, FormatContext& ctx) {
+  auto format(const projectaria::tools::mps::EyeGaze& gaze, FormatContext& ctx) const {
     constexpr double kRadsToDegs = 180.0 / M_PI;
     return format_to(
         ctx.out(),

--- a/core/mps/GlobalPointCloudFormat.h
+++ b/core/mps/GlobalPointCloudFormat.h
@@ -16,20 +16,18 @@
 
 #pragma once
 
-#include <fmt/format.h>
-#include <format/Format.h>
 #include "GlobalPointCloud.h"
+#include "format/Format.h"
 
 /*
  * fmt::format() specialization for GlobalPointPosition
  */
 template <>
-struct fmt::formatter<projectaria::tools::mps::GlobalPointPosition> {
-  // No parse function needed
-
+struct fmt::formatter<projectaria::tools::mps::GlobalPointPosition>
+    : fmt::formatter<std::string_view> {
   // Format the Point object
   template <typename FormatContext>
-  auto format(const projectaria::tools::mps::GlobalPointPosition& point, FormatContext& ctx) {
+  auto format(const projectaria::tools::mps::GlobalPointPosition& point, FormatContext& ctx) const {
     return format_to(
         ctx.out(),
         "GlobalPointPosition(uid = {}, graphUid = {}, position_world = {}, inverseDistanceStd = {:.4f}, distanceStd = {:.4f})",

--- a/core/mps/MpsDataPathsFormat.h
+++ b/core/mps/MpsDataPathsFormat.h
@@ -24,12 +24,11 @@
  * fmt::format() specialization for MpsEyegazeDataPaths
  */
 template <>
-struct fmt::formatter<projectaria::tools::mps::MpsEyegazeDataPaths> {
-  // No parse function needed
-
+struct fmt::formatter<projectaria::tools::mps::MpsEyegazeDataPaths>
+    : fmt::formatter<std::string_view> {
   // Format the MpsEyegazeDataPaths object
   template <typename FormatContext>
-  auto format(const projectaria::tools::mps::MpsEyegazeDataPaths& paths, FormatContext& ctx) {
+  auto format(const projectaria::tools::mps::MpsEyegazeDataPaths& paths, FormatContext& ctx) const {
     return format_to(
         ctx.out(),
         "MPS Eyegaze Data Paths\n--generalEyegaze: {}\n--personalizedEyegaze: {}\n--summary: {}",
@@ -43,12 +42,11 @@ struct fmt::formatter<projectaria::tools::mps::MpsEyegazeDataPaths> {
  * fmt::format() specialization for MpsSlamDataPaths
  */
 template <>
-struct fmt::formatter<projectaria::tools::mps::MpsSlamDataPaths> {
-  // No parse function needed
-
+struct fmt::formatter<projectaria::tools::mps::MpsSlamDataPaths>
+    : fmt::formatter<std::string_view> {
   // Format the MpsSlamDataPaths object
   template <typename FormatContext>
-  auto format(const projectaria::tools::mps::MpsSlamDataPaths& paths, FormatContext& ctx) {
+  auto format(const projectaria::tools::mps::MpsSlamDataPaths& paths, FormatContext& ctx) const {
     return format_to(
         ctx.out(),
         "MPS SLAM Data Paths\n--closedLoopTrajectory: {}\n--openLoopTrajectory: {}\n--semidensePoints: {}\n--semidenseObservations: {}\n--onlineCalibration: {}\n--summary: {}",
@@ -65,12 +63,10 @@ struct fmt::formatter<projectaria::tools::mps::MpsSlamDataPaths> {
  * fmt::format() specialization for MpsDataPaths
  */
 template <>
-struct fmt::formatter<projectaria::tools::mps::MpsDataPaths> {
-  // No parse function needed
-
+struct fmt::formatter<projectaria::tools::mps::MpsDataPaths> : fmt::formatter<std::string_view> {
   // Format the MpsDataPaths object
   template <typename FormatContext>
-  auto format(const projectaria::tools::mps::MpsDataPaths& paths, FormatContext& ctx) {
+  auto format(const projectaria::tools::mps::MpsDataPaths& paths, FormatContext& ctx) const {
     return format_to(
         ctx.out(),
         "MPS Data Paths\n{}\n{}",

--- a/core/mps/OnlineCalibrationFormat.h
+++ b/core/mps/OnlineCalibrationFormat.h
@@ -16,22 +16,21 @@
 
 #pragma once
 #include <fmt/chrono.h>
-#include <fmt/format.h>
-#include <format/Format.h>
+
 #include "OnlineCalibration.h"
 #include "calibration/CameraCalibrationFormat.h"
 #include "calibration/ImuMagnetometerCalibrationFormat.h"
+#include "format/Format.h"
 
 /*
  * fmt::format() specialization for OnlineCalibration
  */
 template <>
-struct fmt::formatter<projectaria::tools::mps::OnlineCalibration> {
-  // No parse function needed
-
+struct fmt::formatter<projectaria::tools::mps::OnlineCalibration>
+    : fmt::formatter<std::string_view> {
   // Format the OnlineCalibration object
   template <typename FormatContext>
-  auto format(const projectaria::tools::mps::OnlineCalibration& calib, FormatContext& ctx) {
+  auto format(const projectaria::tools::mps::OnlineCalibration& calib, FormatContext& ctx) const {
     std::stringstream camCalibsStr;
     for (const auto& camCalib : calib.cameraCalibs) {
       camCalibsStr << fmt::to_string(camCalib) << ", ";

--- a/core/mps/PointObservationFormat.h
+++ b/core/mps/PointObservationFormat.h
@@ -18,18 +18,18 @@
 
 #include <fmt/chrono.h>
 #include <fmt/format.h>
+
 #include "PointObservation.h"
 
 /*
  * fmt::format() specialization for PointObservation
  */
 template <>
-struct fmt::formatter<projectaria::tools::mps::PointObservation> {
-  // No parse function needed
-
+struct fmt::formatter<projectaria::tools::mps::PointObservation>
+    : fmt::formatter<std::string_view> {
   // Format the PointObservation object
   template <typename FormatContext>
-  auto format(const projectaria::tools::mps::PointObservation& obs, FormatContext& ctx) {
+  auto format(const projectaria::tools::mps::PointObservation& obs, FormatContext& ctx) const {
     return format_to(
         ctx.out(),
         "PointObservation(pointUid: {}, frameCaptureTimestamp: {}, cameraSerial: {}, uv: {})",

--- a/core/mps/StaticCameraCalibrationFormat.h
+++ b/core/mps/StaticCameraCalibrationFormat.h
@@ -16,20 +16,19 @@
 
 #pragma once
 
-#include <fmt/format.h>
-#include <format/Format.h>
 #include "StaticCameraCalibration.h"
+#include "format/Format.h"
 
 /*
  * fmt::format() specialization for StaticCameraCalibration
  */
 template <>
-struct fmt::formatter<projectaria::tools::mps::StaticCameraCalibration> {
-  // No parse function needed
-
-  // Format the Point object
+struct fmt::formatter<projectaria::tools::mps::StaticCameraCalibration>
+    : fmt::formatter<std::string_view> {
+  // Format the StaticCameraCalibration object
   template <typename FormatContext>
-  auto format(const projectaria::tools::mps::StaticCameraCalibration& calib, FormatContext& ctx) {
+  auto format(const projectaria::tools::mps::StaticCameraCalibration& calib, FormatContext& ctx)
+      const {
     return format_to(
         ctx.out(),
         "StaticCameraCalibration( cameraUid: {}, graphUid: {}, T_world_cam: {}, width: {}, height: {}, intrinsicsType: {}, intrinsics: {}, startFrameIdx: {}, endFrameIdx: {} )",

--- a/core/mps/TrajectoryFormat.h
+++ b/core/mps/TrajectoryFormat.h
@@ -17,20 +17,20 @@
 #pragma once
 
 #include <fmt/chrono.h>
-#include <fmt/format.h>
-#include <format/Format.h>
+
 #include "Trajectory.h"
+#include "format/Format.h"
 
 /*
  * fmt::format() specialization for OpenLoopTrajectoryPose
  */
 template <>
-struct fmt::formatter<projectaria::tools::mps::OpenLoopTrajectoryPose> {
-  // No parse function needed
-
-  // Format the Point object
+struct fmt::formatter<projectaria::tools::mps::OpenLoopTrajectoryPose>
+    : fmt::formatter<std::string_view> {
+  // Format the OpenLoopTrajectoryPose object
   template <typename FormatContext>
-  auto format(const projectaria::tools::mps::OpenLoopTrajectoryPose& pose, FormatContext& ctx) {
+  auto format(const projectaria::tools::mps::OpenLoopTrajectoryPose& pose, FormatContext& ctx)
+      const {
     return format_to(
         ctx.out(),
         "OpenLoopTrajectory(tracking_timestamp: {}, utc_timestamp: {}, quality_score: {:.4f}, sessionUid: {}, T_odometry_device: {}, deviceLinearVelocity_odometry: {}, angularVelocity_device: {}, gravity_odometry: {})",
@@ -49,12 +49,12 @@ struct fmt::formatter<projectaria::tools::mps::OpenLoopTrajectoryPose> {
  * fmt::format() specialization for ClosedLoopTrajectoryPose
  */
 template <>
-struct fmt::formatter<projectaria::tools::mps::ClosedLoopTrajectoryPose> {
-  // No parse function needed
-
-  // Format the Point object
+struct fmt::formatter<projectaria::tools::mps::ClosedLoopTrajectoryPose>
+    : fmt::formatter<std::string_view> {
+  // Format the ClosedLoopTrajectoryPose object
   template <typename FormatContext>
-  auto format(const projectaria::tools::mps::ClosedLoopTrajectoryPose& pose, FormatContext& ctx) {
+  auto format(const projectaria::tools::mps::ClosedLoopTrajectoryPose& pose, FormatContext& ctx)
+      const {
     return format_to(
         ctx.out(),
         "ClosedLoopTrajectory(tracking_timestamp: {}, utc_timestamp: {}, quality_score: {:.4f}, graphUid: {}, T_world_device: {}, deviceLinearVelocity_device: {}, angularVelocity_device: {}, gravity_world: {})",


### PR DESCRIPTION
Summary: Recent FMT versions are stricter regarding the presence of the `parse` function. If not defined by inheritance it needs now to be defined.

Differential Revision: D52857459


