### PR TITLE
{Feature} exposing camera calibration rescale API to Python.

### DIFF
--- a/core/python/DeviceCalibrationPyBind.h
+++ b/core/python/DeviceCalibrationPyBind.h
@@ -168,6 +168,15 @@ inline void declareCameraCalibration(py::module& m) {
           py::arg("camera_pixel"),
           "Function to unproject a 2d pixel location to a 3d ray, in camera frame, with a number of"
           " validity checks to ensure the unprojection is valid.")
+      .def(
+          "rescale",
+          &CameraCalibration::rescale,
+          py::arg("new_resolution"),
+          py::arg("scale"),
+          py::arg("origin_offset") = Eigen::Vector2d{0, 0},
+          "Obtain a new camera calibration after translation and scaling transform from the original "
+          "camera calibration. <br> transform is done in the order of (1) shift -> (2) scaling:"
+          " new_resolution = (old_resolution - origin_offset*2) * scale")
       .def("__repr__", [](const CameraCalibration& self) { return fmt::to_string(self); });
 
   m.def(

--- a/core/python/TestBindings.py
+++ b/core/python/TestBindings.py
@@ -24,7 +24,8 @@ from projectaria_tools.core.stream_id import RecordableTypeId
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "vrs_path",
+        "--vrs",
+        dest="vrs_path",
         type=str,
         help="path to vrs file",
     )
@@ -78,6 +79,16 @@ def print_sample_calibration(provider):
     imu_calib = device_calib.get_imu_calib("imu-left")
     print(imu_calib.get_label())
     print(imu_calib.get_transform_device_imu())
+
+    # obtain a rescaled camera calibration
+    rescaled_calib = rgb_calib.rescale(new_resolution=(704, 704), scale=0.5)
+    print("testing for camera calibration downscaling (factor = 0.5)")
+    print(
+        f"resolution for original camera is {rgb_calib.get_image_size()}, intrinsics params are: {rgb_calib.projection_params}, valid_radius is {rgb_calib.get_valid_radius()}"
+    )
+    print(
+        f"resolution for new camera is {rescaled_calib.get_image_size()}, intrinsics params are: {rescaled_calib.projection_params}, valid_radius is {rescaled_calib.get_valid_radius()}"
+    )
 
 
 def print_distort_image(provider):


### PR DESCRIPTION
Summary: Exposes `CameraCalibration::rescale()` API from CPP to Python.

Differential Revision: D56370137


