### PR TITLE
{Feature} C++ Sample - VRS Image mutation

### DIFF
--- a/tools/samples/vrs_mutation/CMakeLists.txt
+++ b/tools/samples/vrs_mutation/CMakeLists.txt
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-message("--- Compiling samples.")
-add_subdirectory(pointcloud_colorization)
+find_package(fmt REQUIRED)
 
-add_subdirectory(vrs_mutation)
+add_executable(vrs_mutation main.cpp ImageMutationFilterCopier.h)
+target_link_libraries(vrs_mutation PRIVATE vrs_utils CLI11::CLI11 fmt::fmt)
+target_include_directories(vrs_mutation PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/tools/samples/vrs_mutation/ImageMutationFilterCopier.h
+++ b/tools/samples/vrs_mutation/ImageMutationFilterCopier.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <vrs/StreamId.h>
+#include <vrs/helpers/Strings.h>
+#include <vrs/utils/FilteredFileReader.h>
+#include <vrs/utils/PixelFrame.h>
+
+namespace vrs::utils {
+
+// Abstract PixelFrame mutator to be used in conjunction of
+// ImageMutationFilter to modify VRS frame when performing a VRS copy.
+class UserDefinedImageMutator {
+ public:
+  virtual ~UserDefinedImageMutator() {}
+  // Operator allowing to modify a given PixelFrame (according to its timestamp and streamId)
+  // -> Note the image size (Width, Height, Stride) must be left unchanged
+  virtual bool operator()(
+      double, // timestamp
+      const vrs::StreamId&, // streamId
+      vrs::utils::PixelFrame* // frame
+      ) = 0;
+};
+
+class ImageMutationFilter : public RecordFilterCopier {
+ public:
+  ImageMutationFilter(
+      vrs::RecordFileReader& fileReader,
+      vrs::RecordFileWriter& fileWriter,
+      vrs::StreamId id,
+      const CopyOptions& copyOptions,
+      UserDefinedImageMutator* userDefinedImageMutator)
+      : RecordFilterCopier(fileReader, fileWriter, id, copyOptions),
+        userDefinedImageMutator_(userDefinedImageMutator) {}
+
+  bool shouldCopyVerbatim(const CurrentRecord& record) override {
+    auto tupleId = tuple<Record::Type, uint32_t>(record.recordType, record.formatVersion);
+    const auto& verbatimCopyIter = verbatimCopy_.find(tupleId);
+    if (verbatimCopyIter != verbatimCopy_.end()) {
+      return verbatimCopyIter->second;
+    }
+    const auto& decoders = readers_.find(tuple<StreamId, Record::Type, uint32_t>(
+        record.streamId, record.recordType, record.formatVersion));
+    bool verbatimCopy = decoders == readers_.end() ||
+        (record.recordType == Record::Type::DATA &&
+         decoders->second.recordFormat.getBlocksOfTypeCount(ContentType::IMAGE) == 0);
+    verbatimCopy_[tupleId] = verbatimCopy;
+    return verbatimCopy;
+  }
+  void filterImage(
+      const CurrentRecord& record,
+      size_t /*blockIndex*/,
+      const ContentBlock& cb,
+      vector<uint8_t>& pixels) override {
+    const auto& imageSpec = cb.image();
+
+    // Synchronously read the image data, which is jpg compressed with Aria
+    if (imageSpec.getImageFormat() == vrs::ImageFormat::JPG) {
+      std::shared_ptr<vrs::utils::PixelFrame> frame = std::make_shared<PixelFrame>();
+      frame->readJpegFrame(pixels, cb.getBlockSize());
+
+      // Call user defined mutator on the frame
+      if (userDefinedImageMutator_) {
+        if (!userDefinedImageMutator_->operator()(record.timestamp, record.streamId, &(*frame))) {
+          // If mutator not successful, we return an empty black frame
+          if (!pixels.empty()) {
+            memset(pixels.data(), 0, pixels.size());
+          }
+        }
+      }
+      // Re-encode to JPG
+      frame->jpgCompress(pixels, 90);
+    } else if (imageSpec.getImageFormat() == vrs::ImageFormat::RAW) {
+      // Directly process pixels buffer as you wish
+    }
+  }
+
+ protected:
+  map<tuple<Record::Type, uint32_t>, bool> verbatimCopy_;
+  UserDefinedImageMutator* userDefinedImageMutator_;
+};
+
+} // namespace vrs::utils

--- a/tools/samples/vrs_mutation/Readme.md
+++ b/tools/samples/vrs_mutation/Readme.md
@@ -1,0 +1,78 @@
+# VRS Mutation example
+
+`vrs_mutation` is a sample demonstrating how to create a VRS file copy with on the fly custom image modification (either from images in memory, or previously exported to disk).
+
+## How to run the vrs_mutation example:
+
+### Vertical flip example
+
+This example is setting even rows to be black on all image stream (image operation processed in memory as data is loaded)
+- see `NullifyEvenRowsImageMutator` in main.cpp for the implementation
+
+`vrs_mutation -i <VRS_IN> -o <VRS_OUT> --mutationType NULLIFY_EVEN_ROWS`
+
+### VRS image export reimport
+
+This example allow to reimport vrs images (previously exported to disk)
+- see `VrsExportLoader` in main.cpp for the implementation
+- images could be modified in content (pixel value) but not in size (resolution must remain the same)
+
+`vrs_mutation -i <VRS_IN> -o <VRS_OUT> --VRS_EXPORT_REIMPORT --exportPath <path>`
+
+#### Notes on how to export VRS images to disk
+Here is how to use this workflow (vrs binary can be compiled from [vrs repository](https://github.com/facebookresearch/vrs))
+```
+# 1. Export VRS Frames
+$ vrs extract-images <VRS> --to /tmp/data
+# 2. Modify your image frame
+# - i.e blur/annotate some objects manually or with a script
+#
+# 3. Use VRS Copy with the `VrsExportLoader` Mutator (to replace each VRS frame with the corresponding file on disk)
+vrs_mutation -i <VRS_IN> -o <VRS_OUT> --VRS_EXPORT_REIMPORT --exportPath /tmp/data
+```
+
+# How the VRS image mutation is implemented
+
+The feature is implemented by using the `RecordFilterCopier` concept along a `vrs copy` operation.
+
+By adding a `ImageMutationFilter` abstraction of `RecordFilterCopier` with a custom `UserDefinedImageMutator`, the user can modify on the fly the PixelFrame image read from a given VRS and export it to a new VRS file.
+FYI:
+- Image size and bit depth must remains the same.
+- `ImageMutationFilter::shouldCopyVerbatim` implements the logic to apply the functor only on image stream
+- `ImageMutationFilter::filterImage` implements the JPG buffer codec logic and allow you to access the uncompressed PixelFrame for mutation with your functor
+
+### How to write your how custom image mutation?
+- See the provided examples `NullifyEvenRowsImageMutator`, or extend the `VrsExportLoader`.
+
+```
+struct MyCustomImageMutator : public vrs::utils::UserDefinedImageMutator {
+  bool operator()(double timestamp, const vrs::StreamId& streamId, vrs::utils::PixelFrame* frame)
+      override {
+    if (!frame) { // If frame is invalid, Do nothing.
+      return false;
+    }
+    // If frame is valid:
+    // - apply your image processing function
+    // - or load an image from disk to replace the image buffer
+    // -> Note the image size (Width, Height, Stride) must be left unchanged
+
+    // Image is defined by its PixelFrame:
+    // frame->getWidth()
+    // frame->getHeight()
+    //
+    // frame->wdata() - Pixel image buffer start (of size frame->getStride()*frame->getHeight() )
+    //
+    // You could iterate the image from top to bottom as following:
+    //
+    // const size_t lineLength = frame->getStride();
+    // uint32_t top = 0;
+    // uint32_t bottom = frame->getHeight() - 1;
+    // while (top < bottom) {
+    //   uint8_t* topPixels = frame->wdata() + top * frame->getStride();
+    //   top++;
+    // }
+
+    return true;
+  }
+};
+```

--- a/tools/samples/vrs_mutation/main.cpp
+++ b/tools/samples/vrs_mutation/main.cpp
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cstdlib>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <set>
+#include <string>
+#include <vector>
+
+#include <fmt/core.h>
+#include <vrs/StreamId.h>
+#include <vrs/utils/FilterCopy.h>
+#include <vrs/utils/PixelFrame.h>
+#include <vrs/utils/RecordFileInfo.h>
+
+#include "ImageMutationFilterCopier.h"
+
+#include <CLI/CLI.hpp>
+
+namespace {
+
+// Demonstration on how to implement a variant of the abstract class "UserDefinedImageMutator"
+// The operator is setting row to be black if the row index is % 2
+struct NullifyEvenRowsImageMutator : public vrs::utils::UserDefinedImageMutator {
+  bool operator()(
+      double /*timestamp*/,
+      const vrs::StreamId& /*streamId*/,
+      vrs::utils::PixelFrame* frame) override {
+    // Perform the image operation IFF the frame is valid
+    if (!frame) {
+      return false;
+    }
+    const size_t lineLength = frame->getStride();
+    uint32_t top = 0;
+    uint32_t bottom = frame->getHeight() - 1;
+    while (top < bottom) {
+      if (top % 2 == 0) {
+        uint8_t* rowPixels = frame->wdata() + top * frame->getStride();
+        memset(rowPixels, 0, lineLength);
+      }
+      top++;
+    }
+    return true;
+  }
+};
+
+// Demonstration on how to implement a variant of the abstract class "UserDefinedImageMutator"
+// to reload frame exported by `VRS export`
+struct VrsExportLoader : public vrs::utils::UserDefinedImageMutator {
+  std::string folderPath_;
+  std::string extension_;
+  std::string filenamePostfix_;
+  std::map<std::string, uint64_t> frameCounter_;
+
+  explicit VrsExportLoader(const std::string& folderPath, const std::string& extension = "jpg")
+      : folderPath_(folderPath), extension_(extension) {}
+
+  bool operator()(double timestamp, const vrs::StreamId& streamId, vrs::utils::PixelFrame* frame)
+      override {
+    if (!frame) {
+      return false;
+    }
+    // Initialize frame counter or get back frame counter value
+    if (frameCounter_.count(streamId.getNumericName()) == 0) {
+      frameCounter_[streamId.getNumericName()] = 1;
+    }
+    const uint64_t imageCounter = frameCounter_[streamId.getNumericName()];
+
+    // Build a path format that will match files exported by `vrs export`
+    const std::string path = fmt::format(
+        "{}/{}-{:05}-{:.3f}{}.{}",
+        folderPath_,
+        streamId.getNumericName(), // i.e 214-1
+        imageCounter, // counter in your Mutator (see comment below)
+        timestamp, // timestamp of the frame
+        filenamePostfix_, // default -> ""
+        extension_); // default -> "jpg"
+
+    // Do the necessary work on the image (load and replace pixel data in the Pixel Frame)
+    frame->readJpegFrameFromFile(path, true);
+
+    // increment the frameCounter for this streamId
+    ++frameCounter_[streamId.getNumericName()];
+    return true;
+  }
+};
+
+} // namespace
+
+int main(int argc, const char* argv[]) {
+  std::string mutationType;
+  std::string vrsPathIn;
+  std::string vrsPathOut;
+  std::string vrsExportPath;
+
+  CLI::App app{"VRS file Mutation example by using VRS Copy + Filter mechanism"};
+
+  app.add_option("-i,--in", vrsPathIn, "VRS input")->required();
+  app.add_option("-o,--out", vrsPathOut, "VRS output")->required();
+  app.add_option(
+         "-m,--mutationType",
+         mutationType,
+         "Mutation type:\n"
+         "  - 'NULLIFY_EVEN_ROWS' or 'VRS_EXPORT_REIMPORT'\n"
+         "  If mutation type is VRS_EXPORT_REIMPORT and parameter --exportPath must be specified\n"
+         "  Note: NULLIFY_EVEN_ROWS is shared as a DEMO example only")
+      ->required();
+  app.add_option("-e,--exportPath", vrsExportPath, "VRS export output path");
+
+  CLI11_PARSE(app, argc, argv);
+
+  static const std::set<std::string> mutationsType = {"NULLIFY_EVEN_ROWS", "VRS_EXPORT_REIMPORT"};
+
+  if (mutationsType.find(mutationType) == mutationsType.end()) {
+    std::cerr << "Invalid <MUTATOR_TYPE> option." << std::endl;
+    return EXIT_FAILURE;
+  }
+  if (vrsPathIn == vrsPathOut) {
+    std::cerr << " <VRS_IN> <VRS_OUT> paths must be different." << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  vrs::utils::FilteredFileReader filteredReader;
+  // Initialize VRS Reader and filters
+  filteredReader.setSource(vrsPathIn);
+  filteredReader.openFile();
+  filteredReader.applyFilters({});
+
+  // Configure Copy Filter and initialize the copy
+  const std::string targetPath = vrsPathOut;
+  vrs::utils::CopyOptions copyOptions;
+  copyOptions.setCompressionPreset(vrs::CompressionPreset::Default);
+
+  // Functor to perform image processing/conversion
+  // See here the some example of Mutator (Vertical flip, Nullify, Reload VRSexport frame)
+  std::shared_ptr<vrs::utils::UserDefinedImageMutator> imageMutator;
+  if (mutationType == "NULLIFY_EVEN_ROWS") {
+    imageMutator = std::make_shared<NullifyEvenRowsImageMutator>();
+  } else if (mutationType == "VRS_EXPORT_REIMPORT") {
+    imageMutator = std::make_shared<VrsExportLoader>(vrsExportPath);
+  }
+
+  auto copyMakeStreamFilterFunction = [&imageMutator](
+                                          vrs::RecordFileReader& fileReader,
+                                          vrs::RecordFileWriter& fileWriter,
+                                          vrs::StreamId streamId,
+                                          const vrs::utils::CopyOptions& copyOptions)
+      -> std::unique_ptr<vrs::utils::RecordFilterCopier> {
+    auto imageMutatorFilter = std::make_unique<vrs::utils::ImageMutationFilter>(
+        fileReader, fileWriter, streamId, copyOptions, imageMutator.get());
+    return imageMutatorFilter;
+  };
+
+  const int statusCode =
+      filterCopy(filteredReader, targetPath, copyOptions, copyMakeStreamFilterFunction);
+
+  return statusCode;
+}


### PR DESCRIPTION
Summary:
Add a C++ sample showing how to perform VRS image mutation:
- from VRS frame in memory
- from VRS frame previously exported to disk
  - frames that eventually has been modified in content but not in resolution

Reviewed By: xiaqingp

Differential Revision: D56211737
