### PR TITLE
{Build} Continuous integration - macSilicon and macIntel

### DIFF
--- a/.github/workflows/build-and-test-pixi.yml
+++ b/.github/workflows/build-and-test-pixi.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, macos-14] # macos-14 is macSilicon
+        os: [ubuntu-latest, macos-13, macos-14] # macos-14 is macSilicon
     steps:
       - name : Setup repo
         uses: actions/checkout@v4
@@ -27,9 +27,9 @@ jobs:
           sudo rm /etc/paths.d/mono-commands
 
       - name : Setup pixi
-        uses: prefix-dev/setup-pixi@v0.5.1
+        uses: prefix-dev/setup-pixi@v0.6.0
         with:
-          pixi-version: v0.13.0
+          pixi-version: v0.20.1
           cache: true
 
       - name: C++ - Build and Test

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,11 +8,11 @@ on:
 
 jobs:
   build:
-    name: Build projectaria_tools on ${{ matrix.os }} / ${{ matrix.cmakeOptions }}
+    name: Build projectaria_tools on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest,  macOS-latest]
+        os: [ubuntu-latest,  macos-13, macos-14] # macos-14 is macSilicon
     steps:
       - name : Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/build-and-test_projects.yml
+++ b/.github/workflows/build-and-test_projects.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest,  macOS-latest]
+        os: [ubuntu-latest, macos-13, macos-14]  # macos-14 is macSilicon
         project: [
           PROJECTARIA_TOOLS_BUILD_PROJECTS_ADT,
           PROJECTARIA_TOOLS_BUILD_TOOLS]


### PR DESCRIPTION
Summary:
Continue fix introduced in bdd4825141dbb06b9c80de3bc701eca830d0afab to be sure we are using mac Intel/Silicon runner for our continuous integration.

Short story: macos-latest is now picking macos-14 that is only running M1, so we are now explicitly asking for macos-13 (macIntel) and macos-14 (macSilicon)

Differential Revision: D57055322


