### PR TITLE
{Build} Continous Integration - Pangolin

### DIFF
--- a/.github/workflows/build-and-test_projects.yml
+++ b/.github/workflows/build-and-test_projects.yml
@@ -75,6 +75,7 @@ jobs:
 
           # Build and install Pangolin (optional)
           cd /tmp; git clone https://github.com/stevenlovegrove/Pangolin.git \
+            && cd Pangolin && git checkout d25ec009bd5cd9ac4b4a2b6750fec5093c46d601 && cd .. \
             && mkdir Pangolin_Build && cd Pangolin_Build \
             && cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TOOLS=OFF -DBUILD_PANGOLIN_PYTHON=OFF -DBUILD_EXAMPLES=OFF ../Pangolin/ \
             && sudo make -j$thread install;


### PR DESCRIPTION
Summary:
Install libepoxy-dev when processing .github/workflows/build-and-test_projects.yml.
Pangolin is making this new dependency required on Linux system https://github.com/stevenlovegrove/Pangolin/commit/661500c4f5522057da3cb6c98a1a0e6479d2da59#diff-c55fb07b54826ed2f13b4d62ca8a866e6c623c0f5482f586882dd101c328f92bR123

Differential Revision: D58072840


