### PR TITLE
{Feature} VrsDataProvider - Support retrieval of the VRS file tags

### DIFF
--- a/core/data_provider/RecordReaderInterface.cpp
+++ b/core/data_provider/RecordReaderInterface.cpp
@@ -88,10 +88,15 @@ RecordReaderInterface::RecordReaderInterface(
     streamIdToCondition_.emplace(streamId, std::make_unique<std::condition_variable>());
     streamIdToLastReadRecord_.emplace(streamId, nullptr);
   }
+  fileTags_ = reader_->getTags();
 }
 
 std::set<vrs::StreamId> RecordReaderInterface::getStreamIds() const {
   return streamIds_;
+}
+
+std::map<std::string, std::string> RecordReaderInterface::getFileTags() const {
+  return fileTags_;
 }
 
 SensorDataType RecordReaderInterface::getSensorDataType(const vrs::StreamId& streamId) const {

--- a/core/data_provider/RecordReaderInterface.h
+++ b/core/data_provider/RecordReaderInterface.h
@@ -45,6 +45,7 @@ class RecordReaderInterface {
       const std::shared_ptr<TimeSyncMapper>& timeSyncMapper);
 
   std::set<vrs::StreamId> getStreamIds() const;
+  [[nodiscard]] std::map<std::string, std::string> getFileTags() const;
   SensorDataType getSensorDataType(const vrs::StreamId& streamId) const;
 
   size_t getNumData(const vrs::StreamId& streamId) const;
@@ -78,6 +79,7 @@ class RecordReaderInterface {
 
   std::set<vrs::StreamId> streamIds_;
   std::map<vrs::StreamId, SensorDataType> streamIdToSensorDataType_;
+  std::map<std::string, std::string> fileTags_;
 
   std::map<vrs::StreamId, std::shared_ptr<ImageSensorPlayer>> imagePlayers_;
   std::map<vrs::StreamId, std::shared_ptr<MotionSensorPlayer>> motionPlayers_;

--- a/core/data_provider/VrsDataProvider.cpp
+++ b/core/data_provider/VrsDataProvider.cpp
@@ -142,6 +142,10 @@ const std::set<vrs::StreamId> VrsDataProvider::getAllStreams() const {
   return interface_->getStreamIds();
 }
 
+std::map<std::string, std::string> VrsDataProvider::getFileTags() const {
+  return interface_->getFileTags();
+}
+
 size_t VrsDataProvider::getNumData(const vrs::StreamId& streamId) const {
   return interface_->getNumData(streamId);
 }

--- a/core/data_provider/VrsDataProvider.h
+++ b/core/data_provider/VrsDataProvider.h
@@ -52,6 +52,12 @@ class VrsDataProvider {
   const std::set<vrs::StreamId> getAllStreams() const;
 
   /**
+   * @brief Get the tags map for all the underlying files. Does not include any stream tags.
+   * @return The tags map for all underlying files.
+   */
+  std::map<std::string, std::string> getFileTags() const;
+
+  /**
    * @brief Get SensorDataType from streamId.
    * @param streamId The ID of a sensor's stream.
    * @return An entry of SensorDataType assigned for streamId, if stream with this ID exists in vrs,

--- a/core/data_provider/test/VrsDataProviderFileTagsTest.cpp
+++ b/core/data_provider/test/VrsDataProviderFileTagsTest.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <data_provider/VrsDataProvider.h>
+
+#include <gtest/gtest.h>
+
+using namespace projectaria::tools::data_provider;
+
+#define STRING(x) #x
+#define XSTRING(x) std::string(STRING(x)) + "aria_unit_test_sequence_calib.vrs"
+
+static const std::string ariaTestDataPath = XSTRING(TEST_FOLDER);
+
+#define DEFAULT_LOG_CHANNEL "TestLog"
+#include <logging/Checks.h>
+#include <logging/Log.h>
+
+namespace {
+constexpr const uint32_t kFileTagsNum = 25;
+}
+
+TEST(VrsDataProvider, getFileTags) {
+  auto provider = createVrsDataProvider(ariaTestDataPath);
+  auto fileTags = provider->getFileTags();
+  EXPECT_EQ(fileTags.size(), kFileTagsNum);
+}

--- a/core/python/VrsDataProviderPyBind.h
+++ b/core/python/VrsDataProviderPyBind.h
@@ -171,6 +171,10 @@ inline void declareVrsDataProvider(py::module& m) {
           },
           "Get all available streams from the vrs file.")
       .def(
+          "get_file_tags",
+          [](const VrsDataProvider& self) { return self.getFileTags(); },
+          "Get the tags map from the vrs file.")
+      .def(
           "get_sensor_data_type",
           &VrsDataProvider::getSensorDataType,
           py::arg("stream_id"),

--- a/core/python/test/corePyBindTest.py
+++ b/core/python/test/corePyBindTest.py
@@ -245,3 +245,8 @@ class CalibrationTests(unittest.TestCase):
                 test_pixel=test_pixel, cam_calib=src_calib
             )
         )
+
+    def test_vrs_file_tags(self) -> None:
+        provider = data_provider.create_vrs_data_provider(vrs_filepath)
+        file_tags = provider.get_file_tags()
+        assert len(file_tags) == 25


### PR DESCRIPTION
Summary: VRS file tags can be retrieved in VRS file reader classes. Modified `VrsDataProvider` to use this functionality through `RecordReaderInterface`. Added the Python binding for the new `VrsDataProvider::getFileTags` function in `VrsDataProviderPyBind.h`.

Differential Revision: D58093298


