### PR TITLE
{Feature} Python | vrs_to_mp4 - add vrs_device_time_ns array to 'description' file tag in mp4

### DIFF
--- a/projectaria_tools/utils/vrs_to_mp4.py
+++ b/projectaria_tools/utils/vrs_to_mp4.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,35 +13,8 @@
 # limitations under the License.
 
 import argparse
-import json
-import os
-import shutil
-import tempfile
 
-import numpy as np
-from moviepy.editor import AudioFileClip
-from moviepy.video.io.VideoFileClip import VideoClip
-
-from projectaria_tools.core import data_provider
-from projectaria_tools.core.sensor_data import TimeDomain
-from projectaria_tools.core.stream_id import StreamId
-from projectaria_tools.core.vrs import extract_audio_track
-
-
-def extract_audio(vrs_file_path: str) -> str:
-    """Extract audio from a VRS file as a wav file in a temporary folder."""
-    temp_folder = tempfile.mkdtemp()
-    if not temp_folder:
-        return None
-    # else continue process vrs audio extraction
-    json_output_string = extract_audio_track(
-        vrs_file_path, os.path.join(temp_folder, "audio.wav")
-    )
-    json_output = json.loads(json_output_string)  # Convert string to Dict
-    if json_output and json_output["status"] == "success":
-        return json_output["output"]
-    # Else we were not able to export a Wav file from the VRS file
-    return None
+from projectaria_tools.utils.vrs_to_mp4_utils import convert_vrs_to_mp4
 
 
 def parse_args():
@@ -60,154 +32,29 @@ def parse_args():
         help="path to the VIDEO file you want to create",
     )
     parser.add_argument(
+        "--log_folder",
+        type=str,
+        required=False,
+        help="Folder to store the log: mp4_to_vrs_time_map.csv, audio_log.json, audio.wav",
+    )
+    parser.add_argument(
         "--downsample",
         type=int,
         required=False,
-        default=2,
+        default=1,
         help="Downsampling factor on VRS images (Must be >=1)",
     )
     return parser.parse_args()
 
 
-class Vrs2MoviePyFrameConverter:
-    """
-    Class used to convert the VRS RGB frame to a moviepy Video Clip.
-    A Vrs2MoviePyFrameConverter object is defined as callable to be used as a make_frame(t) functor by moviepy.
-    """
-
-    def sample_frame_and_timestamp(self, image_data_and_record) -> [np.ndarray, int]:
-        """
-        Return the image frame and corresponding timestamp.
-            Image is down sampled and rotated if required.
-        """
-        img = image_data_and_record.image_data_and_record()[0].to_numpy_array().copy()
-
-        if self.down_sampling_factor_ > 1:
-            img = img[:: self.down_sampling_factor_, :: self.down_sampling_factor_]
-        # Rotate image
-        img = np.rot90(img, -1)
-
-        capture_timestamp = image_data_and_record.image_data_and_record()[
-            1
-        ].capture_timestamp_ns
-        return [img, capture_timestamp]
-
-    def __init__(self, vrs_path: str, down_sampling_factor: int = 1):
-        self.down_sampling_factor_ = down_sampling_factor
-
-        ##
-        # Initialize the VRS data provider
-        self.provider_ = data_provider.create_vrs_data_provider(vrs_path)
-        if not self.provider_:
-            raise ValueError(f"vrs file: '{vrs_path}' cannot be read")
-
-        self.rgb_stream_id_ = StreamId("214-1")
-
-        ##
-        # Configure a deliver queue to provide only RGB image data stream
-
-        deliver_option = self.provider_.get_default_deliver_queued_options()
-        deliver_option.deactivate_stream_all()
-        deliver_option.activate_stream(self.rgb_stream_id_)
-
-        self.seq_ = self.provider_.deliver_queued_sensor_data(deliver_option)
-        self.iter_data_ = iter(self.seq_)
-        image_data_and_record = next(self.iter_data_)
-        self.last_valid_frame_, self.last_timestamp_ = self.sample_frame_and_timestamp(
-            image_data_and_record
-        )
-        self.first_timestamp_ = self.last_timestamp_
-        self.dropped_frames_count_ = 0
-
-    def stream_fps(self) -> int:
-        """Collect stream characteristic, Get the time period between two image sample."""
-        return int(self.provider_.get_nominal_rate_hz(self.rgb_stream_id_))
-
-    def stream_duration(self) -> int:
-        """Return the RGB stream duration in seconds."""
-        t_first = self.provider_.get_first_time_ns(
-            self.rgb_stream_id_, TimeDomain.DEVICE_TIME
-        )
-        t_last = self.provider_.get_last_time_ns(
-            self.rgb_stream_id_, TimeDomain.DEVICE_TIME
-        )
-        import math
-
-        # Keeping only integer seconds (no decimals)
-        duration_in_seconds = math.floor((t_last - t_first) / 1e9)
-        return duration_in_seconds
-
-    def dropped_frames_count(self) -> int:
-        """
-        Return the number of counted frame drop (frame that did not match the expect timestamp)
-        """
-        return self.dropped_frames_count_
-
-    def __call__(self, t) -> np.ndarray:
-        """
-        Create a functor compatible with the make_frame(t) functor concept of moviePy VideoClip.
-        This function return VRS frame in time alignment with the time {t} request of moviePy.
-        - If a frame is not present as a given expected time, we count the frame as missing/dropped and return the last valid frame.
-        """
-        try:
-            moviepy_timestamp_us = t * 1e9
-            vrs_timestamp = self.last_timestamp_ - self.first_timestamp_
-
-            # If time match we return the last frame
-            if vrs_timestamp > moviepy_timestamp_us:
-                # VRS is in advance, so we return the last frame we collected
-                self.dropped_frames_count_ += 1
-                return self.last_valid_frame_
-            else:
-                obj = next(self.iter_data_)
-                # We get a new image from the queue
-                (
-                    self.last_valid_frame_,
-                    self.last_timestamp_,
-                ) = self.sample_frame_and_timestamp(obj)
-            return self.last_valid_frame_
-
-        except StopIteration:
-            print("We have exhausted the VRS stream, keep sending last VRS frame")
-            return self.last_valid_frame_
-
-
 def main():
     args = parse_args()
-
-    if args.downsample < 1:
-        raise ValueError(
-            f"Invalid downsample value: {args.downsample}. Must be greater than or equal to 1"
-        )
-
-    # Test to see if we can extract the VRS audio stream as a wav file
-    audio_path = None
-    audio_path = extract_audio(args.vrs)
-
-    ##
-    # Prepare the Vrs2MoviePyFrameConverter and configure a moviePy video clip
-    frame_converter = Vrs2MoviePyFrameConverter(args.vrs, args.downsample)
-    duration_in_seconds = frame_converter.stream_duration()
-    # Create a VideoClip of the desired duration, and using the Vrs Source
-    video_writer_clip = VideoClip(frame_converter, duration=duration_in_seconds)
-    # Add the audio as audio clip if any
-    if audio_path:
-        audio_clip = AudioFileClip(audio_path)
-        video_writer_clip = video_writer_clip.set_audio(audio_clip)
-
-    # Configure the VideoWriter and run the process
-    output_video_fps = frame_converter.stream_fps()
-    video_writer_clip.write_videofile(args.output_video, fps=output_video_fps)
-    video_writer_clip.close()
-
-    # If audio file has been extracted, remove the containing temporary folder that we created
-    if audio_path:
-        shutil.rmtree(os.path.dirname(audio_path))
-
-    print("VRS to MP4 summary:")
-    print(f"Created a {duration_in_seconds} seconds video.")
-    print(f"- FPS: {output_video_fps}")
-    print(f"- Drop frame(s) count: {frame_converter.dropped_frames_count()}")
+    convert_vrs_to_mp4(
+        args.vrs,
+        args.output_video,
+        log_folder=args.log_folder,
+        down_sample_factor=args.downsample,
+    )
 
 
 if __name__ == "__main__":

--- a/projectaria_tools/utils/vrs_to_mp4_utils.py
+++ b/projectaria_tools/utils/vrs_to_mp4_utils.py
@@ -1,0 +1,282 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import csv
+import json
+import os
+import shutil
+import tempfile
+
+import numpy as np
+from moviepy.audio.AudioClip import AudioClip
+from moviepy.editor import AudioFileClip
+from moviepy.video.io.VideoFileClip import VideoClip
+from PIL import Image
+
+from projectaria_tools.core import data_provider
+from projectaria_tools.core.sensor_data import TimeDomain, TimeQueryOptions
+from projectaria_tools.core.stream_id import StreamId
+
+
+def max_signed_value_for_bytes(n):
+    return (1 << (8 * n - 1)) - 1
+
+
+def convert_vrs_to_mp4(
+    vrs_file: str, output_video: str, log_folder=None, down_sample_factor=1
+):
+    """Convert a VRS file to MP4 video."""
+    use_temp_folder = False
+    if log_folder is None:
+        # If no log folder is provided, we will create a temporary one
+        use_temp_folder = True
+        log_folder = tempfile.mkdtemp()
+    elif os.path.exists(log_folder) is False:
+        os.mkdir(log_folder)
+
+    # Create a vrs to mp4 converter
+    converter = Vrs2Mp4Converter(vrs_file, down_sample_factor)
+    duration_ns = converter.duration_ns()
+    duration_in_second = duration_ns * 1e-9
+    video_writer_clip = VideoClip(converter.make_frame, duration=duration_in_second)
+
+    # extract audio from vrs file
+    if converter.contain_audio():
+        audio_writer_clip = AudioClip(
+            converter.make_audio_data,
+            duration=duration_in_second,
+            fps=converter.audio_config.sample_rate,
+        )
+        audio_writer_clip.nchannels = converter.audio_config.num_channels
+        audio_writer_clip.write_audiofile(
+            os.path.join(log_folder, "audio.mp3"),
+            fps=converter.audio_config.sample_rate,
+            buffersize=converter.audio_buffersize(),
+        )
+        audio_clip = AudioFileClip(
+            os.path.join(log_folder, "audio.mp3"),
+        )
+        video_writer_clip = video_writer_clip.set_audio(audio_clip)
+        audio_writer_clip.close()
+
+    video_writer_clip.write_videofile(output_video, fps=converter.video_fps())
+    video_writer_clip.close()
+
+    converter.write_mp4_to_vrs_time_ns(log_folder)
+    converter.write_log(log_folder)
+
+    # remove log folder if it is a temporary folder
+    if use_temp_folder:
+        shutil.rmtree(log_folder)
+
+
+class Vrs2Mp4Converter:
+    """
+    A class that is used to convert VRS RGB frames to a moviepy Video Clip and save to MP4.
+    make_frame(t)->np.ndarray is called to insert each RGB frame into MP4 for timestamp t in MP4 domain
+    make_audio_data(t)->np.ndarray is called to insert audio stream into MP4
+    """
+
+    def __init__(self, vrs_path: str, down_sampling_factor: int = 1):
+        self.down_sampling_factor_ = down_sampling_factor
+
+        self.provider_ = data_provider.create_vrs_data_provider(vrs_path)
+        if not self.provider_:
+            raise ValueError(f"vrs file: '{vrs_path}' cannot be read")
+
+        # Extract RGB frame with streamId "214-1" and audio stream "231-1"
+        self.image_streamid_ = StreamId("214-1")
+        self.audio_streamid_ = StreamId("231-1")
+
+        self.contain_rgb_ = self.provider_.check_stream_is_active(self.image_streamid_)
+        self.contain_audio_ = self.provider_.check_stream_is_active(
+            self.audio_streamid_
+        )
+
+        if self.contain_rgb_ is False:
+            raise SystemExit("The vrs does not contain RGB frames to convert to mp4")
+
+        self.start_timestamp_ns_ = self.provider_.get_first_time_ns(
+            self.image_streamid_, TimeDomain.DEVICE_TIME
+        )
+        self.end_timestamp_ns_ = self.provider_.get_last_time_ns(
+            self.image_streamid_, TimeDomain.DEVICE_TIME
+        )
+        if self.contain_audio_ is True:
+            self.audio_config = self.provider_.get_audio_configuration(
+                self.audio_streamid_
+            )
+            self.audio_max_value_ = max_signed_value_for_bytes(4)
+
+            # RECORD_TIME for audio is the START of a Record
+            # DEVICE_TIME for audio is the END of a Record
+            # start_audio_timestamp use RECORD_TIME while end_audio_timestamp use DEVICE_TIME
+            # The time period between both times is the duration of the MP4
+            self.start_timestamp_ns_ = self.provider_.get_first_time_ns(
+                self.audio_streamid_, TimeDomain.RECORD_TIME
+            )
+            self.end_timestamp_ns_ = self.provider_.get_last_time_ns(
+                self.audio_streamid_, TimeDomain.DEVICE_TIME
+            )
+
+        # initialize the first image data
+        image_data_and_record = self.provider_.get_image_data_by_time_ns(
+            self.image_streamid_,
+            self.start_timestamp_ns_,
+            TimeDomain.DEVICE_TIME,
+            TimeQueryOptions.CLOSEST,
+        )
+        self.image_prev_index_ = self.provider_.get_index_by_time_ns(
+            self.image_streamid_,
+            self.start_timestamp_ns_,
+            TimeDomain.DEVICE_TIME,
+            TimeQueryOptions.CLOSEST,
+        )
+        img_array = self.convert_image(image_data_and_record)
+        self.last_valid_image_ = img_array
+        self.last_time_ns_ = image_data_and_record[1].capture_timestamp_ns
+
+        # Initialize logging data
+        self.mp4_to_vrs_timestamp_ns_ = {}
+        self.invalid_frames_ = np.array([])
+        self.skipped_frames_ = np.array([])
+        self.duplicated_frames_ = np.array([])
+
+    # write mp4 timestamp to vrs device timestamp in csv file
+    def write_mp4_to_vrs_time_ns(self, log_path: str):
+        output_file = os.path.join(log_path, "mp4_to_vrs_time_ns.csv")
+        with open(output_file, "w") as csv_file:
+            writer = csv.writer(csv_file)
+            writer.writerow(
+                ["mp4_time_ns", "relative_vrs_device_time_ns", "vrs_device_time_ns"]
+            )
+            for key, value in self.mp4_to_vrs_timestamp_ns_.items():
+                writer.writerow([key, value - self.start_timestamp_ns_, value])
+
+    def contain_audio(self) -> bool:
+        return self.contain_audio_
+
+    # write log file
+    def write_log(self, log_path: str):
+        output_file = os.path.join(log_path, "vrs_to_mp4_log.json")
+        log_data = {}
+        log_data["num_mp4_frames"] = len(self.mp4_to_vrs_timestamp_ns_)
+        log_data["down_sampling_factor_"] = self.down_sampling_factor_
+        log_data["num_skipped_frames"] = len(self.skipped_frames_)
+        log_data["num_duplicated_frames_"] = len(self.duplicated_frames_)
+        log_data["num_invalid_frames_"] = len(self.invalid_frames_)
+        log_data["first_video_timestamp_ns"] = self.start_timestamp_ns_
+        log_data["end_video_timestamp_ns"] = self.end_timestamp_ns_
+        log_data["video_duration_ns"] = self.duration_ns()
+
+        for key, value in log_data.items():
+            print(f"{key} : {value}")
+
+        with open(output_file, "w") as outfile:
+            json.dump(log_data, outfile)
+
+    def convert_image(self, image_data_and_record):
+        img_array = image_data_and_record[0].to_numpy_array().copy()
+        if self.down_sampling_factor_ > 1:
+            img_array = Image.fromarray(img_array)
+            img_array = img_array.resize(
+                [
+                    int(img_array.width / self.down_sampling_factor_),
+                    int(img_array.height / self.down_sampling_factor_),
+                ]
+            )
+            img_array = np.array(img_array)
+        img_array = np.rot90(img_array, -1)
+        return img_array
+
+    def duration_ns(self):
+        return self.end_timestamp_ns_ - self.start_timestamp_ns_
+
+    def video_fps(self):
+        return self.provider_.get_nominal_rate_hz(self.image_streamid_)
+
+    # add each frame to the video clip based on the closest image frame to the vrs_timestamp_ns
+    def make_frame(self, t) -> np.ndarray:
+        video_timestamp_ns = t * 1e9
+        vrs_timestamp_ns = int(self.start_timestamp_ns_ + video_timestamp_ns)
+        image_data_and_record = self.provider_.get_image_data_by_time_ns(
+            self.image_streamid_,
+            vrs_timestamp_ns,
+            TimeDomain.DEVICE_TIME,
+            TimeQueryOptions.CLOSEST,
+        )
+
+        image_index = self.provider_.get_index_by_time_ns(
+            self.image_streamid_,
+            vrs_timestamp_ns,
+            TimeDomain.DEVICE_TIME,
+            TimeQueryOptions.CLOSEST,
+        )
+        if image_index > self.image_prev_index_ + 1:
+            self.skipped_frames_ = np.append(
+                self.skipped_frames_, self.image_prev_index_ + 1
+            )
+        elif image_index == self.image_prev_index_:
+            self.duplicated_frames_ = np.append(
+                self.duplicated_frames_, self.image_prev_index_
+            )
+
+        if image_data_and_record[0].is_valid() is False:
+            self.invalid_frames_ = np.append(self.invalid_frames_, image_index)
+            self.duplicated_frames_ = np.append(
+                self.duplicated_frames_, self.image_prev_index_
+            )
+            self.mp4_to_vrs_timestamp_ns_[video_timestamp_ns] = self.last_time_ns_
+            return self.last_valid_image_
+
+        image_device_time_ns = image_data_and_record[1].capture_timestamp_ns
+        self.mp4_to_vrs_timestamp_ns_[video_timestamp_ns] = image_device_time_ns
+
+        self.last_valid_image_ = self.convert_image(image_data_and_record)
+        self.image_prev_index_ = image_index
+        self.last_time_ns_ = image_device_time_ns
+
+        return self.last_valid_image_
+
+    # Number of samples of each records (e.g. 2048 or 4096)
+    def audio_buffersize(self):
+        audio_data = self.provider_.get_audio_data_by_index(self.audio_streamid_, 1)
+        return len(audio_data[1].capture_timestamps_ns)
+
+    # add each audio record to the MP4
+    def make_audio_data(self, t) -> np.ndarray:
+        if self.contain_audio_ is False:
+            raise SystemExit(
+                "The vrs does not contain audio and cannot be used to extract audio data."
+            )
+
+        # length of input variable len(t) == audio_buffersize - 1
+        if np.size(t) == 1:
+            return 0
+        query_timestamp_ns = t * 1e9
+        vrs_timestamp_ns = int(self.start_timestamp_ns_ + query_timestamp_ns[0])
+
+        # obtaining the closest audio record to the vrs_timestamp_ns
+        audio_data_and_config = self.provider_.get_audio_data_by_time_ns(
+            self.audio_streamid_,
+            vrs_timestamp_ns,
+            TimeDomain.RECORD_TIME,
+            TimeQueryOptions.CLOSEST,
+        )
+        audio_data = np.array(audio_data_and_config[0].data)
+        audio_data = audio_data.astype(np.float64) / self.audio_max_value_
+
+        # return all channels
+        # a subset of channels create crackle sounds
+        return audio_data


### PR DESCRIPTION
Summary:
File tag "description" now stores an array of `vrs_device_time_ns` for each frame in the mp4.

- To save array of timestamps, call `save_timestamp_to_mp4()`
- To retrieve the timestamp array, call `get_timestamp_from_mp4()`
- add check for the saved mp4 metadata

Reviewed By: SeaOtocinclus

Differential Revision: D58122814
