### PR TITLE
{Feature} VrsDataProvider - Support providing VRS metadata and time sync mode of file

### DIFF
--- a/core/data_provider/CMakeLists.txt
+++ b/core/data_provider/CMakeLists.txt
@@ -61,7 +61,10 @@ target_link_libraries(timesync_mapper PUBLIC error_handler vrslib players)
 
 add_library(record_reader_interface STATIC RecordReaderInterface.cpp RecordReaderInterface.h)
 target_include_directories(record_reader_interface PUBLIC "../")
-target_link_libraries(record_reader_interface PUBLIC sensor_data)
+target_link_libraries(record_reader_interface PUBLIC
+        sensor_data
+        nlohmann_json::nlohmann_json
+        )
 
 add_library(timestamp_index_mapper STATIC TimestampIndexMapper.cpp TimestampIndexMapper.h)
 target_include_directories(timestamp_index_mapper PUBLIC "../")
@@ -76,10 +79,12 @@ target_sources(utils INTERFACE QueryMapByTimestamp.h)
 target_include_directories(utils INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 
 add_library(vrs_data_provider STATIC
-        VrsDataProvider.cpp VrsDataProvider.h
+        VrsDataProvider.cpp VrsDataProvider.h VrsMetadata.h
         VrsDataProviderFactory.cpp
         SensorDataSequence.cpp SensorDataSequence.h)
-target_include_directories(vrs_data_provider PUBLIC "../")
+target_include_directories(vrs_data_provider PUBLIC
+        "../"
+        )
 target_link_libraries(vrs_data_provider PUBLIC
         aria_stream_ids
         deliver_queued_options
@@ -92,4 +97,4 @@ target_link_libraries(vrs_data_provider PUBLIC
         timestamp_index_mapper
         aria_calib_rescale_and_crop
         device_calibration_json
-)
+        )

--- a/core/data_provider/RecordReaderInterface.h
+++ b/core/data_provider/RecordReaderInterface.h
@@ -23,6 +23,7 @@
 
 #include <data_provider/SensorData.h>
 #include <data_provider/TimeSyncMapper.h>
+#include <data_provider/VrsMetadata.h>
 #include <vrs/MultiRecordFileReader.h>
 
 namespace projectaria::tools::data_provider {
@@ -46,6 +47,7 @@ class RecordReaderInterface {
 
   std::set<vrs::StreamId> getStreamIds() const;
   [[nodiscard]] std::map<std::string, std::string> getFileTags() const;
+  [[nodiscard]] std::optional<VrsMetadata> getMetadata() const;
   SensorDataType getSensorDataType(const vrs::StreamId& streamId) const;
 
   size_t getNumData(const vrs::StreamId& streamId) const;
@@ -74,12 +76,15 @@ class RecordReaderInterface {
 
   void setReadImageContent(vrs::StreamId streamId, bool readContent);
 
+  [[nodiscard]] std::optional<MetadataTimeSyncMode> getTimeSyncMode() const;
+
  private:
   std::shared_ptr<vrs::MultiRecordFileReader> reader_;
 
   std::set<vrs::StreamId> streamIds_;
   std::map<vrs::StreamId, SensorDataType> streamIdToSensorDataType_;
   std::map<std::string, std::string> fileTags_;
+  std::optional<VrsMetadata> vrsMetadata_;
 
   std::map<vrs::StreamId, std::shared_ptr<ImageSensorPlayer>> imagePlayers_;
   std::map<vrs::StreamId, std::shared_ptr<MotionSensorPlayer>> motionPlayers_;

--- a/core/data_provider/VrsDataProvider.cpp
+++ b/core/data_provider/VrsDataProvider.cpp
@@ -146,6 +146,14 @@ std::map<std::string, std::string> VrsDataProvider::getFileTags() const {
   return interface_->getFileTags();
 }
 
+std::optional<VrsMetadata> VrsDataProvider::getMetadata() const {
+  return interface_->getMetadata();
+}
+
+std::optional<MetadataTimeSyncMode> VrsDataProvider::getTimeSyncMode() const {
+  return interface_->getTimeSyncMode();
+}
+
 size_t VrsDataProvider::getNumData(const vrs::StreamId& streamId) const {
   return interface_->getNumData(streamId);
 }

--- a/core/data_provider/VrsDataProvider.h
+++ b/core/data_provider/VrsDataProvider.h
@@ -58,6 +58,21 @@ class VrsDataProvider {
   std::map<std::string, std::string> getFileTags() const;
 
   /**
+   * @brief Get a pointer to an instance of VrsMetadata for an underlying VRS file,
+   * if the metadata exists in the file.
+   * The constructor of RecordReaderInterface populates a struct from
+   * file tags.
+   * @return Metadata for the underlying VRS file in an instance of VrsMetadata.
+   */
+  std::optional<VrsMetadata> getMetadata() const;
+
+  /**
+   * @brief The time-sync mode of the recording, if it exists in the file.
+   * @return The time-sync-mode enum value for the recording.
+   */
+  std::optional<MetadataTimeSyncMode> getTimeSyncMode() const;
+
+  /**
    * @brief Get SensorDataType from streamId.
    * @param streamId The ID of a sensor's stream.
    * @return An entry of SensorDataType assigned for streamId, if stream with this ID exists in vrs,

--- a/core/data_provider/VrsMetadata.h
+++ b/core/data_provider/VrsMetadata.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <map>
+#include <string>
+
+namespace projectaria::tools::data_provider {
+
+enum class MetadataTimeSyncMode : int {
+  NotEnabled = 0,
+  Timecode = 1,
+  Ntp = 2,
+  TicSyncClient = 3,
+  TicSyncServer = 4,
+};
+
+/**
+ * @brief A convenience struct for VRS files containing recordings.
+ * @details This struct is not exactly the VRS file metadata tag, but includes
+ * essential information, such as device serial, from other tags in the VRS
+ * file. There may be some keys in the file metadata that are not copied to this
+ * convenience struct.
+ */
+struct VrsMetadata {
+  std::string deviceSerial;
+  std::string sharedSessionId;
+  std::string recordingProfile;
+  MetadataTimeSyncMode timeSyncMode = MetadataTimeSyncMode::NotEnabled;
+  std::string deviceId;
+  std::string filename;
+  uint64_t startTimeEpochSec = 0;
+  uint64_t endTimeEpochSec = 0;
+  uint64_t durationSec = 0;
+};
+
+} // namespace projectaria::tools::data_provider

--- a/core/data_provider/test/CMakeLists.txt
+++ b/core/data_provider/test/CMakeLists.txt
@@ -98,3 +98,15 @@ add_test(NAME vrs_data_provider_get_data_by_index_test WORKING_DIRECTORY ${CMAKE
              COMMAND $<TARGET_FILE:vrs_data_provider_get_data_by_index_test>)
 target_compile_definitions(vrs_data_provider_get_data_by_index_test
     PRIVATE -DTEST_FOLDER=${CMAKE_CURRENT_SOURCE_DIR}/../../../data/)
+
+add_executable(vrs_data_provider_file_access_test VrsDataProviderFileAccessTest.cpp)
+target_link_libraries(vrs_data_provider_file_access_test
+    PUBLIC
+        vrs_data_provider
+        GTest::Main
+)
+gtest_discover_tests(vrs_data_provider_file_access_test)
+add_test(NAME vrs_data_provider_file_access_test WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+             COMMAND $<TARGET_FILE:vrs_data_provider_file_access_test>)
+target_compile_definitions(vrs_data_provider_file_access_test
+    PRIVATE -DTEST_FOLDER=${CMAKE_CURRENT_SOURCE_DIR}/../../../data/)

--- a/core/data_provider/test/VrsDataProviderFileAccessTest.cpp
+++ b/core/data_provider/test/VrsDataProviderFileAccessTest.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <data_provider/VrsDataProvider.h>
+
+#include <gtest/gtest.h>
+
+using namespace projectaria::tools::data_provider;
+
+#define STRING(x) #x
+#define XSTRING(x) std::string(STRING(x)) + "aria_unit_test_sequence_calib.vrs"
+
+static const std::string ariaTestDataPath = XSTRING(TEST_FOLDER);
+
+#define DEFAULT_LOG_CHANNEL "TestLog"
+#include <logging/Checks.h>
+#include <logging/Log.h>
+
+namespace {
+constexpr const uint32_t kFileTagsNum = 25;
+}
+
+TEST(VrsDataProvider, getFileTags) {
+  auto provider = createVrsDataProvider(ariaTestDataPath);
+  auto fileTags = provider->getFileTags();
+  EXPECT_EQ(fileTags.size(), kFileTagsNum);
+}
+
+TEST(VrsDataProvider, getMetadata) {
+  auto provider = createVrsDataProvider(ariaTestDataPath);
+  EXPECT_EQ(provider->getTimeSyncMode(), MetadataTimeSyncMode::NotEnabled);
+  const auto& maybeMetadata = provider->getMetadata();
+  EXPECT_TRUE(maybeMetadata.has_value());
+  const auto& metadata = maybeMetadata.value();
+
+  EXPECT_EQ(metadata.deviceSerial, "1WM093701M1276");
+  EXPECT_EQ(metadata.recordingProfile, "profile9");
+  EXPECT_EQ(metadata.sharedSessionId, "");
+  EXPECT_EQ(metadata.filename, "d3c61c3a-18ec-460e-a35c-cec9579494ca.vrs");
+  EXPECT_EQ(metadata.timeSyncMode, MetadataTimeSyncMode::NotEnabled);
+  EXPECT_EQ(metadata.deviceId, "35ec1d5b-689d-4531-a0c9-1c8ff42d2e89");
+  EXPECT_EQ(metadata.startTimeEpochSec, 1649265055);
+}

--- a/core/python/VrsDataProviderPyBind.h
+++ b/core/python/VrsDataProviderPyBind.h
@@ -153,6 +153,23 @@ inline void declareDeliverQueued(py::module& m) {
 }
 
 inline void declareVrsDataProvider(py::module& m) {
+  py::enum_<MetadataTimeSyncMode>(m, "MetadataTimeSyncMode")
+      .value("NotEnabled", MetadataTimeSyncMode::NotEnabled)
+      .value("Timecode", MetadataTimeSyncMode::Timecode)
+      .value("Ntp", MetadataTimeSyncMode::Ntp)
+      .value("TicSyncClient", MetadataTimeSyncMode::TicSyncClient)
+      .value("TicSyncServer", MetadataTimeSyncMode::TicSyncServer);
+  py::class_<VrsMetadata>(m, "VrsMetadata")
+      .def(py::init<>())
+      .def_readonly("device_serial", &VrsMetadata::deviceSerial)
+      .def_readonly("shared_session_id", &VrsMetadata::sharedSessionId)
+      .def_readonly("recording_profile", &VrsMetadata::recordingProfile)
+      .def_readonly("time_sync_mode", &VrsMetadata::timeSyncMode)
+      .def_readonly("device_id", &VrsMetadata::deviceId)
+      .def_readonly("filename", &VrsMetadata::filename)
+      .def_readonly("start_time_epoch_sec", &VrsMetadata::startTimeEpochSec)
+      .def_readonly("end_time_epoch_sec", &VrsMetadata::endTimeEpochSec)
+      .def_readonly("duration_sec", &VrsMetadata::durationSec);
   py::class_<VrsDataProvider, std::shared_ptr<VrsDataProvider>>(
       m,
       "VrsDataProvider",
@@ -174,6 +191,14 @@ inline void declareVrsDataProvider(py::module& m) {
           "get_file_tags",
           [](const VrsDataProvider& self) { return self.getFileTags(); },
           "Get the tags map from the vrs file.")
+      .def(
+          "get_metadata",
+          &VrsDataProvider::getMetadata,
+          "Get metadata if the loaded file is a VRS file.")
+      .def(
+          "get_time_sync_mode",
+          &VrsDataProvider::getTimeSyncMode,
+          "Get time-sync mode if the loaded file is a VRS file.")
       .def(
           "get_sensor_data_type",
           &VrsDataProvider::getSensorDataType,

--- a/core/python/test/corePyBindTest.py
+++ b/core/python/test/corePyBindTest.py
@@ -250,3 +250,23 @@ class CalibrationTests(unittest.TestCase):
         provider = data_provider.create_vrs_data_provider(vrs_filepath)
         file_tags = provider.get_file_tags()
         assert len(file_tags) == 25
+
+
+class DataProviderTests(unittest.TestCase):
+    def test_vrs_file_metadata(self) -> None:
+        provider = data_provider.create_vrs_data_provider(vrs_filepath)
+        file_metadata = provider.get_metadata()
+        assert file_metadata.device_serial == "1WM093701M1276"
+        assert file_metadata.recording_profile == "profile9"
+        assert file_metadata.shared_session_id == ""
+        assert file_metadata.filename == "d3c61c3a-18ec-460e-a35c-cec9579494ca.vrs"
+        assert (
+            file_metadata.time_sync_mode
+            == data_provider.MetadataTimeSyncMode.NotEnabled
+        )
+        assert (
+            provider.get_time_sync_mode()
+            == data_provider.MetadataTimeSyncMode.NotEnabled
+        )
+        assert file_metadata.device_id == "35ec1d5b-689d-4531-a0c9-1c8ff42d2e89"
+        assert file_metadata.start_time_epoch_sec == 1649265055


### PR DESCRIPTION
Summary:
Added:
- `VrsDataProvider::getMetadata` and `VrsDataProvider::getTimeSyncMode` to the C++ API.
- Corresponding `get_metadata` and `get_time_sync_mode` Python bindings for the new functions.

Differential Revision: D58241450
