### PR TITLE
{Build} Core - Template specialization

### DIFF
--- a/core/image/ImageVariant.h
+++ b/core/image/ImageVariant.h
@@ -65,7 +65,7 @@ using ManagedImageVariant = std::variant<
     ManagedImage4F32,
     ManagedImageU64>;
 
-using PixelValueVariant = std::variant<uint8_t, float, uint16_t, uint64_t, Eigen::half>;
+using PixelValueVariant = std::variant<float, uint8_t, uint16_t, uint64_t, Eigen::half>;
 /**
  * @brief Returns the pixel at specified coordinate in an image
  * @param imageVariant the input image
@@ -133,7 +133,7 @@ struct PixelVisitor {
 
   template <class T, int M, int D>
   PixelValueVariant operator()(
-      const projectaria::tools::image::Image<Eigen::Matrix<T, D, 1>, M>& image) const {
+      const projectaria::tools::image::Image<Eigen::Matrix<T, D, 1, 0, D, 1>, M>& image) const {
     if (channel < 0 || channel >= D) {
       throw std::runtime_error("Channel value out of range");
     }

--- a/core/python/ImageDataHelper.h
+++ b/core/python/ImageDataHelper.h
@@ -26,8 +26,8 @@ namespace projectaria::tools::image {
 namespace py = pybind11;
 
 using PyArrayVariant = std::variant<
-    py::array_t<uint8_t>,
     py::array_t<float>,
+    py::array_t<uint8_t>,
     py::array_t<uint16_t>,
     py::array_t<uint64_t>,
     py::array_t<Eigen::half>>;
@@ -44,7 +44,7 @@ struct PyArrayVariantVisitor {
     size_t width = image.width();
     size_t height = image.height();
     size_t stride = image.pitch();
-    return PyArrayVariant{py::array_t<T>({height, width}, {stride, sizeof(T)}, (T*)(image.data()))};
+    return {py::array_t<T>({height, width}, {stride, sizeof(T)}, (T*)(image.data()))};
   }
   template <class T, int M, int D>
   PyArrayVariant operator()(
@@ -53,7 +53,7 @@ struct PyArrayVariantVisitor {
     size_t height = image.height();
     size_t stride = image.pitch();
     size_t channel = D;
-    return PyArrayVariant{py::array_t<T>(
+    return {py::array_t<T>(
         {height, width, channel}, {stride, channel * sizeof(T), sizeof(T)}, (T*)(image.data()))};
   }
 };


### PR DESCRIPTION
Summary:
Make template specialization compatible with MSVC
- MSVC does not accept partial template specialization for Eigen matrix types and need all the list of template arguments

- Use default constructor `call {} rather than X()`
- Reorder variant to have all uint_x side by side

Differential Revision: D59924382
