### PR TITLE
{Feature} Core - Undistortion - Reduce memory usage

### DIFF
--- a/core/calibration/utility/Distort.cpp
+++ b/core/calibration/utility/Distort.cpp
@@ -29,7 +29,7 @@ image::ManagedImageVariant distortByCalibration(
     Eigen::Vector3d rayDir = dstCalib.unprojectNoChecks(dstPixel.template cast<double>());
     std::optional<Eigen::Vector2d> maybeSrcPixel = srcCalib.project(rayDir);
     if (!maybeSrcPixel) {
-      return std::nullopt;
+      return {};
     } else {
       return maybeSrcPixel->template cast<float>();
     }


### PR DESCRIPTION
Summary:
- Use less memory by avoiding creating an array of x,y pixel positions
- Use std::fill to set the image to default color rather than setting each pixel individually

Differential Revision: D60598150
