### PR TITLE
{feature} ASE vrs calibration support

### DIFF
--- a/core/calibration/loader/AriaCalibRescaleAndCrop.cpp
+++ b/core/calibration/loader/AriaCalibRescaleAndCrop.cpp
@@ -40,6 +40,7 @@ CameraCalibration rescaleAriaRgb(
       "Supported downscaled image size are assumed to be (1408, 1408) or (704, 704) for Aria RGB images. Detected size: ({}, {})",
       newImageSize.x(),
       newImageSize.y());
+
   double rescaleFactor = newImageSize == Eigen::Vector2i(1408, 1408) ? 0.5 : 0.25;
   return camCalib.rescale(newImageSize, rescaleFactor, {32.0, 32.0});
 }

--- a/core/calibration/loader/SensorCalibrationJson.h
+++ b/core/calibration/loader/SensorCalibrationJson.h
@@ -21,7 +21,9 @@
 
 namespace projectaria::tools::calibration {
 
-CameraCalibration parseCameraCalibrationFromJson(const nlohmann::json& json);
+CameraCalibration parseCameraCalibrationFromJson(
+    const nlohmann::json& json,
+    bool aseSimulated = false);
 ImuCalibration parseImuCalibrationFromJson(const nlohmann::json& json);
 MagnetometerCalibration parseMagnetometerCalibrationFromJson(const nlohmann::json& json);
 BarometerCalibration parseBarometerCalibrationFromJson(const nlohmann::json& json);


### PR DESCRIPTION
Summary: This diff allows for reading ASE simulated VRS in projectaria_tools. The main issue was that ASE datasets has RGB resolutions as 704x704, and the VRS file also contains the already-scaled RGB calibration. This diff seeks to support loading this type of data.

Differential Revision: D51872439
