### PR TITLE
{Build} Continous Integration - Deactivate MPS notebook testing

### DIFF
--- a/.github/workflows/build-and-test-pixi.yml
+++ b/.github/workflows/build-and-test-pixi.yml
@@ -49,7 +49,7 @@ jobs:
 
           # Running the notebooks
           jupyter nbconvert --execute --inplace dataprovider_quickstart_tutorial.ipynb
-          jupyter nbconvert --execute --inplace mps_quickstart_tutorial.ipynb
+          # jupyter nbconvert --execute --inplace mps_quickstart_tutorial.ipynb
 
       - name : Test python viewers
         shell: pixi run bash {0}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -99,14 +99,5 @@ jobs:
           # Running the notebooks
           jupyter nbconvert --execute --inplace dataprovider_quickstart_tutorial.ipynb
 
-          # Install additional required dependencies
-          if [ "$RUNNER_OS" == "Linux" ]; then
-            sudo apt-get install -y curl unzip
-          elif [ "$RUNNER_OS" == "macOS" ]; then
-            brew install curl unzip
-          else
-            echo "$RUNNER_OS not supported"
-            exit 1
-          fi
-          pip3 install plotly
-          jupyter nbconvert --execute --inplace mps_quickstart_tutorial.ipynb
+          # pip3 install plotly
+          # jupyter nbconvert --execute --inplace mps_quickstart_tutorial.ipynb


### PR DESCRIPTION
Summary: Deactivate mps notebook testing until the team figure out what is happening with GitHub and CDN cache link for hand_tracking_v2.zip

Differential Revision: D61140488
