### PR TITLE
{Build} CI - Don't run "build and test" workflow if they are touching documentation

### DIFF
--- a/.github/workflows/build-and-test-pixi.yml
+++ b/.github/workflows/build-and-test-pixi.yml
@@ -3,8 +3,12 @@ name: Build and Test - Pixi
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "**/website/**"
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "**/website/**"
 
 jobs:
   build:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -3,8 +3,12 @@ name: Build and Test
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "**/website/**"
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "**/website/**"
 
 jobs:
   build:

--- a/.github/workflows/build-and-test_projects.yml
+++ b/.github/workflows/build-and-test_projects.yml
@@ -3,8 +3,12 @@ name: Build projects
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "**/website/**"
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "**/website/**"
 
 jobs:
   build:

--- a/.github/workflows/publish-website.yml
+++ b/.github/workflows/publish-website.yml
@@ -3,8 +3,12 @@ name: publish website
 on:
   push:
     branches: [ main ]
+    paths:
+      - "**/website/**"
   pull_request:
     branches: [ main ]
+    paths:
+      - "**/website/**"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Summary: If we are changing the website we don't need to run the CI for C++ and Python and vice-versa.

Differential Revision: D61229650
