### PR TITLE
{Build} CI - Remove unecessary boost modules

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -41,12 +41,10 @@ jobs:
                 libfmt-dev \
                 libturbojpeg-dev libpng-dev \
                 liblz4-dev libzstd-dev libxxhash-dev \
-                libboost-chrono-dev \
                 libboost-date-time-dev \
                 libboost-filesystem-dev \
                 libboost-iostreams-dev \
-                libboost-system-dev \
-                libboost-thread-dev
+                libboost-system-dev
 
               # Clean APT cache
               sudo apt-get clean

--- a/.github/workflows/build-and-test_projects.yml
+++ b/.github/workflows/build-and-test_projects.yml
@@ -43,12 +43,10 @@ jobs:
                 libfmt-dev \
                 libturbojpeg-dev libpng-dev \
                 liblz4-dev libzstd-dev libxxhash-dev \
-                libboost-chrono-dev \
                 libboost-date-time-dev \
                 libboost-filesystem-dev \
                 libboost-iostreams-dev \
-                libboost-system-dev \
-                libboost-thread-dev
+                libboost-system-dev
 
               # Clean APT cache
               sudo apt-get clean

--- a/.github/workflows/build-wheels-and-deploy.yml
+++ b/.github/workflows/build-wheels-and-deploy.yml
@@ -48,12 +48,10 @@ jobs:
               libfmt-dev \
               libturbojpeg-dev libpng-dev \
               liblz4-dev libzstd-dev libxxhash-dev \
-              libboost-chrono-dev \
               libboost-date-time-dev \
               libboost-filesystem-dev \
               libboost-iostreams-dev \
-              libboost-system-dev \
-              libboost-thread-dev
+              libboost-system-dev
             # Clean APT cache
             sudo apt-get clean
       - name: Install projectaria_tools

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,12 +35,10 @@ RUN sudo apt-get install -y libpython3-dev python3-pip;
 # Install VRS dependencies and compile/install VRS
 
 RUN sudo apt-get install -y \
-    libboost-chrono-dev \
     libboost-date-time-dev \
     libboost-filesystem-dev \
     libboost-iostreams-dev \
     libboost-system-dev \
-    libboost-thread-dev \
     libfmt-dev \
     libgmock-dev libgtest-dev \
     liblz4-dev \

--- a/cmake/Setup3rdParty.cmake
+++ b/cmake/Setup3rdParty.cmake
@@ -23,7 +23,7 @@ FetchContent_Declare(
 FetchContent_Declare(
   vrs
   GIT_REPOSITORY  https://github.com/facebookresearch/vrs.git
-  GIT_TAG        36b785597175ee8b6a0b291b203df4799522b65b # master July 24, 2024.
+  GIT_TAG        b5b854ea618f45fdce8c5d69e11cc879845adfc9 # master August 14, 2024.
 )
 # Override config for vrs
 option(UNIT_TESTS OFF)


### PR DESCRIPTION
Summary:
VRS has evolved and some modules are no longer required

Taking here a more recent version of VRS and updating the boost dependencies to match

Tested locally with:
```
pixi run run_c
pixi run run_python
```

Differential Revision: D61865452
