### PR TITLE
{Feature} MPS - Fix VersionReader inclusion in CMake rules

### DIFF
--- a/core/mps/CMakeLists.txt
+++ b/core/mps/CMakeLists.txt
@@ -48,6 +48,7 @@ add_library(mps
     StaticCameraCalibration.h
     StaticCameraCalibrationFormat.h
     StaticCameraCalibrationReader.h StaticCameraCalibrationReader.cpp
+    VersionReader.h VersionReader.cpp
 )
 target_link_libraries(mps
     PUBLIC


### PR DESCRIPTION
Summary: Following D62899334, we introduced a build regression, we are fixing here the inclusion of the new files in the CMake rules for the mps library.

Reviewed By: maieneuro

Differential Revision: D62970870
