### PR TITLE
{Feature} Python - remove unused python import

### DIFF
--- a/core/python/MpsPyBind.h
+++ b/core/python/MpsPyBind.h
@@ -347,7 +347,7 @@ void exportMps(py::module& m) {
       [](const std::string& path, StreamCompressionMode& mode) -> GlobalPointCloud {
         auto warnings = pybind11::module::import("warnings");
         warnings.attr("warn")(
-            "readGlobalPointCloud(path, mode) is deprecated, use readGlobalPointCloud(path) instead.");
+            "read_global_point_cloud(path, mode) is deprecated, use read_global_point_cloud(path) instead.");
 
         return readGlobalPointCloud(path);
       },
@@ -395,7 +395,7 @@ void exportMps(py::module& m) {
       [](const std::string& path, StreamCompressionMode& mode) -> PointObservations {
         auto warnings = pybind11::module::import("warnings");
         warnings.attr("warn")(
-            "readPointObservations(path, mode) is deprecated, use readPointObservations(path) instead.");
+            "read_point_observations(path, mode) is deprecated, use read_point_observations(path) instead.");
 
         return readPointObservations(path);
       },

--- a/projectaria_tools/utils/viewer_mps.py
+++ b/projectaria_tools/utils/viewer_mps.py
@@ -17,7 +17,7 @@ import os
 
 from pathlib import Path
 
-from typing import Callable, List, Optional, Tuple
+from typing import Callable, List, Optional
 
 import numpy as np
 

--- a/projectaria_tools/utils/viewer_projects_aea.py
+++ b/projectaria_tools/utils/viewer_projects_aea.py
@@ -18,7 +18,7 @@ import numpy as np
 import rerun as rr
 from PIL import Image
 
-from projectaria_tools.core import calibration, mps
+from projectaria_tools.core import mps
 from projectaria_tools.core.mps.utils import (
     filter_points_from_confidence,
     filter_points_from_count,


### PR DESCRIPTION
Summary: Remove unused python import in viewer_mps and viewer_projects_aea

Reviewed By: nickcharron

Differential Revision: D64429056


