### PR TITLE
{Feature} Python - Core - Fixing CameraCalibration getter

### DIFF
--- a/core/calibration/CameraCalibration.h
+++ b/core/calibration/CameraCalibration.h
@@ -41,6 +41,7 @@ class CameraCalibration {
    * @brief Constructor with a list of parameters for CameraCalibration.
    * @param label The label of the camera, e.g. "camera-slam-left".
    * @param projectionModelType The type of camera projection model, e.g. ModelType::Linear
+   * @param projectionParams The projection parameters
    * @param T_Device_Camera The extrinsics of camera in Device frame.
    * @param imageWidth Width of camera image.
    * @param imageHeight Height of camera image.

--- a/core/python/DeviceCalibrationPyBind.h
+++ b/core/python/DeviceCalibrationPyBind.h
@@ -202,10 +202,26 @@ inline void declareCameraCalibration(py::module& m) {
           &CameraCalibration::isVisible,
           py::arg("camera_pixel"),
           "Function to check whether a pixel is within the valid area of the sensor plane.")
-      .def("model_name", &CameraCalibration::modelName)
+      .def(
+          "model_name",
+          [](const CameraCalibration& self) -> CameraProjection::ModelType {
+            auto warnings = pybind11::module::import("warnings");
+            warnings.attr("warn")(
+                "model_name(stream_id) is deprecated, use get_model_name() instead.");
+            return self.modelName();
+          })
+      .def("get_model_name", &CameraCalibration::modelName)
       .def("get_principal_point", &CameraCalibration::getPrincipalPoint)
       .def("get_focal_lengths", &CameraCalibration::getFocalLengths)
-      .def("projection_params", &CameraCalibration::projectionParams)
+      .def(
+          "projection_params",
+          [](const CameraCalibration& self) -> Eigen::VectorXd {
+            auto warnings = pybind11::module::import("warnings");
+            warnings.attr("warn")(
+                "projection_params() is deprecated, use get_projection_params() instead.");
+            return self.projectionParams();
+          })
+      .def("get_projection_params", &CameraCalibration::projectionParams)
       .def(
           "project_no_checks",
           &CameraCalibration::projectNoChecks,

--- a/core/python/DeviceCalibrationPyBind.h
+++ b/core/python/DeviceCalibrationPyBind.h
@@ -121,6 +121,7 @@ inline void declareCameraCalibration(py::module& m) {
   Args:
     label: The label of the camera, e.g. "camera-slam-left".
     projection_model_type The type of camera projection model, e.g. ModelType::Linear
+    projection_params: The projection parameters.
     T_Device_Camera: The extrinsics of camera in Device frame.
     image_width: Width of camera image.
     image_height: Height of camera image.
@@ -146,6 +147,7 @@ inline void declareCameraCalibration(py::module& m) {
   Args:
     label: The label of the camera, e.g. "camera-slam-left".
     projection_model_type The type of camera projection model, e.g. ModelType::Linear
+    projection_params: The projection parameters.
     T_Device_Camera: The extrinsics of camera in Device frame.
     image_width: Width of camera image.
     image_height: Height of camera image.
@@ -175,6 +177,7 @@ inline void declareCameraCalibration(py::module& m) {
     label: The label of the camera, e.g. "camera-slam-left".
     projection_model_type The type of camera projection model, e.g. ModelType::Linear
     T_Device_Camera: The extrinsics of camera in Device frame.
+    projection_params: The projection parameters.
     image_width: Width of camera image.
     image_height: Height of camera image.
     maybe_valid_radius: [optional] radius of a circular mask that represents the valid area on


### PR DESCRIPTION
Summary:
`model_name` and `projection_parameters` function are getter, so they should be prefixed with `get_X` to be consistent with the API.

We are marking those as deprecated and added the new `get_X` function

Differential Revision: D64851296


