### PR TITLE
Add --web argument to run viewer in web browser or desktop app (applied for viewer_mps and viewer_aria_sensors)

### DIFF
--- a/projectaria_tools/utils/viewer_aria_sensors.py
+++ b/projectaria_tools/utils/viewer_aria_sensors.py
@@ -62,7 +62,7 @@ def main():
     
     # Run the viewer in the web browser or desktop app
     if args.web:
-        rr.serve()
+        rr.serve_web()
     else:
         rr.spawn()
         

--- a/projectaria_tools/utils/viewer_aria_sensors.py
+++ b/projectaria_tools/utils/viewer_aria_sensors.py
@@ -58,7 +58,12 @@ def main():
     device_calibration = provider.get_device_calibration()
 
     # Spawn rerun and log things we want to see
-    rr.init("Aria_Sensor_Viewer", spawn=(not args.rrd_output_path))
+    rr.init("Aria Sensors Data Viewer", spawn=(not args.rrd_output_path and not args.web))
+
+    if args.web:
+        rr.serve()
+    else:
+        rr.spawn()
     if args.rrd_output_path:
         print(f"Saving .rrd file to {args.rrd_output_path}")
         rr.save(args.rrd_output_path)
@@ -149,6 +154,13 @@ def main():
             media_type=rr.MediaType.MARKDOWN,
         ),
     )
+    if args.web:
+        # Keep the server running
+        try:
+            while True:
+                pass
+        except KeyboardInterrupt:
+            print("Shutting down server...")
 
 
 #

--- a/projectaria_tools/utils/viewer_aria_sensors.py
+++ b/projectaria_tools/utils/viewer_aria_sensors.py
@@ -59,11 +59,13 @@ def main():
 
     # Spawn rerun and log things we want to see
     rr.init("Aria Sensors Data Viewer", spawn=(not args.rrd_output_path and not args.web))
-
+    
+    # Run the viewer in the web browser or desktop app
     if args.web:
         rr.serve()
     else:
         rr.spawn()
+        
     if args.rrd_output_path:
         print(f"Saving .rrd file to {args.rrd_output_path}")
         rr.save(args.rrd_output_path)

--- a/projectaria_tools/utils/viewer_mps.py
+++ b/projectaria_tools/utils/viewer_mps.py
@@ -727,7 +727,7 @@ def main() -> None:
     
     # Run the viewer in the web browser or desktop app
     if args.web:
-        rr.serve()
+        rr.serve_web()
     else:
         rr.spawn()
 

--- a/projectaria_tools/utils/viewer_mps.py
+++ b/projectaria_tools/utils/viewer_mps.py
@@ -742,7 +742,12 @@ def main() -> None:
         jpeg_quality=args.jpeg_quality,
         rrd_output_path=args.rrd_output_path,
     )
-
-
+    if args.web:
+        # Keep the server running
+        try:
+            while True:
+                pass
+        except KeyboardInterrupt:
+            print("Shutting down server...")
 if __name__ == "__main__":
     main()

--- a/projectaria_tools/utils/viewer_mps.py
+++ b/projectaria_tools/utils/viewer_mps.py
@@ -724,6 +724,7 @@ def main() -> None:
 
     # Initializing Rerun viewer 
     rr.init("MPS Data Viewer", spawn=(not args.rrd_output_path and not args.web))
+    
     # Run the viewer in the web browser or desktop app
     if args.web:
         rr.serve()

--- a/projectaria_tools/utils/viewer_mps.py
+++ b/projectaria_tools/utils/viewer_mps.py
@@ -107,6 +107,13 @@ def parse_args():
         action="store_true",
         help="If set, the raw fisheye RGB images are shown without being undistorted.",
     )
+    # User can choose to run the viewer in the web browser
+    parser.add_argument(
+        '--web',
+        action='store_true',
+        help='Run viewer in web browser'
+    )
+
     return parser.parse_args()
 
 
@@ -715,8 +722,13 @@ def main() -> None:
         print("Nothing to display.")
         exit(1)
 
-    # Initializing Rerun viewer
-    rr.init("MPS Data Viewer", spawn=(not args.rrd_output_path))
+    # Initializing Rerun viewer 
+    rr.init("MPS Data Viewer", spawn=(not args.rrd_output_path and not args.web))
+    # Run the viewer in the web browser or desktop app
+    if args.web:
+        rr.serve()
+    else:
+        rr.spawn()
 
     log_to_rerun(
         vrs_path=args.vrs,

--- a/setup.py
+++ b/setup.py
@@ -158,7 +158,7 @@ def main():
         install_requires=[
             "numpy",
             "requests",  # Required for datasets downloader
-            "rerun-sdk>=0.16.0",
+            "rerun-sdk>=0.20.0",
             "tqdm",
         ],
         extras_require={


### PR DESCRIPTION
- Added --web argument to viewer_mps.py and viewer_aria_sensors.py
- Ensured the server keeps running when --web is used
- Updated initialization and logging to be consistent across web and desktop versions