### PR TITLE
{Feature} Core - Vignetting - Pybind - devignetting

### DIFF
--- a/core/calibration/DeviceCalibration.h
+++ b/core/calibration/DeviceCalibration.h
@@ -16,14 +16,12 @@
 
 #pragma once
 
+#include <calibration/DeviceCadExtrinsics.h>
+#include <calibration/SensorCalibration.h>
+#include <sophus/se3.hpp>
 #include <map>
 #include <optional>
 #include <string>
-
-#include <sophus/se3.hpp>
-
-#include <calibration/DeviceCadExtrinsics.h>
-#include <calibration/SensorCalibration.h>
 
 namespace projectaria::tools::calibration {
 
@@ -156,6 +154,22 @@ class DeviceCalibration {
    */
   const std::string& getOriginLabel() const;
 
+  /**
+   * @brief set the folder path of the vignetting mask.
+   * @param maskFolderPath The folder path of the vignetting mask.
+   * @return void
+   */
+  void setDevignettingMaskFolderPath(const std::string& maskFolderPath);
+  /**
+   * @brief Get devignetting mask based on label and image size.
+   * devignetting_mask = 1/vignetting_mask
+   * devignetted_image = devignetting_mask * original_image
+   * @param label The label of the camera
+   * now supporting "camera-slam-left", "camera-slam-right", "camera-rgb"
+   * @return Vignetting mask in Eigen::MatrixXf format.
+   */
+  Eigen::MatrixXf loadDevignettingMask(const std::string& label);
+
  private:
   friend void tryCropAndScaleCameraCalibration(
       DeviceCalibration& deviceCalibration,
@@ -177,6 +191,7 @@ class DeviceCalibration {
 
   std::string deviceSubtype_;
   std::string originLabel_ = "";
+  std::string devignettingMaskFolderPath_;
 };
 
 } // namespace projectaria::tools::calibration

--- a/core/image/utility/CMakeLists.txt
+++ b/core/image/utility/CMakeLists.txt
@@ -19,3 +19,7 @@ target_link_libraries(image_distort PUBLIC image PRIVATE dispenso)
 add_library(image_debayer Debayer.cpp Debayer.h)
 target_include_directories(image_debayer PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../..)
 target_link_libraries(image_debayer PUBLIC image)
+
+add_library(image_devignetting Devignetting.cpp Devignetting.h)
+target_include_directories(image_devignetting PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../..)
+target_link_libraries(image_devignetting PUBLIC image)

--- a/core/image/utility/Devignetting.cpp
+++ b/core/image/utility/Devignetting.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Devignetting.h"
+
+namespace projectaria::tools::image {
+
+template <class T, int MaxVal>
+ManagedImage<T, DefaultImageAllocator<T>, MaxVal> devignettingImage(
+    const Image<T, MaxVal>& srcImage,
+    const Eigen::MatrixXf& devignettingMask) {
+  ManagedImage<T, DefaultImageAllocator<T>, MaxVal> dstImage(srcImage.width(), srcImage.height());
+  // Note: Image class uses col, row convention while Eigen::MatrixXf uses row, col
+  // convention.
+  for (int col = 0; col < srcImage.width(); ++col) {
+    for (int row = 0; row < srcImage.height(); ++row) {
+      if constexpr (DefaultImageValTraits<T>::isEigen) {
+        auto val = srcImage(col, row).template cast<double>() *
+            std::min(static_cast<double>(devignettingMask(row, col)),
+                     255.0 / srcImage(col, row).template cast<double>().maxCoeff());
+        using Scalar = typename DefaultImageValTraits<T>::Scalar;
+        dstImage(col, row) = val.template cast<Scalar>();
+      } else {
+        double val = static_cast<double>(srcImage(col, row)) *
+            static_cast<double>(devignettingMask(row, col));
+        val = std::min(val, 255.0);
+        dstImage(col, row) = static_cast<T>(val);
+      }
+    }
+  }
+  return dstImage;
+}
+
+ManagedImageVariant devignetting(
+    const ImageVariant& srcImage,
+    const Eigen::MatrixXf& devignettingMask) {
+  return std::visit(
+      [&devignettingMask](const auto& srcImage) -> image::ManagedImageVariant {
+        return devignettingImage(srcImage, devignettingMask);
+      },
+      srcImage);
+}
+
+} // namespace projectaria::tools::image

--- a/core/image/utility/Devignetting.h
+++ b/core/image/utility/Devignetting.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <image/ImageVariant.h>
+
+namespace projectaria::tools::image {
+
+/**
+ * @brief Apply devignetting to an image using a vignetting mask.
+ * @param srcImage The input image to be processed.
+ * @param devignettingMask The vignetting mask to be applied to the image.
+ * @return The devignetted image.
+ */
+ManagedImageVariant devignetting(
+    const ImageVariant& srcImage,
+    const Eigen::MatrixXf& devignettingMask);
+} // namespace projectaria::tools::image

--- a/core/python/CMakeLists.txt
+++ b/core/python/CMakeLists.txt
@@ -23,4 +23,4 @@ FetchContent_MakeAvailable(pybind11)
 
 add_subdirectory(${pybind11_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}/pybind)
 pybind11_add_module(_core_pybinds ${CMAKE_CURRENT_SOURCE_DIR}/bindings.cpp)
-target_link_libraries(_core_pybinds PUBLIC mps vrs_data_provider image_debayer vrs_health_check)
+target_link_libraries(_core_pybinds PUBLIC mps vrs_data_provider image_debayer image_devignetting vrs_health_check)

--- a/core/python/DeviceCalibrationPyBind.h
+++ b/core/python/DeviceCalibrationPyBind.h
@@ -578,7 +578,20 @@ inline void declareDeviceCalibration(py::module& m) {
       .def(
           "get_origin_label",
           &DeviceCalibration::getOriginLabel,
-          "obtain the definition of Origin (or Device in T_Device_Sensor).");
+          "obtain the definition of Origin (or Device in T_Device_Sensor).")
+      .def(
+          "set_devignetting_mask_folder_path",
+          &DeviceCalibration::setDevignettingMaskFolderPath,
+          py::arg("mask_folder_path"),
+          "Set the devignetting mask folder path.")
+      .def(
+          "load_devignetting_mask",
+          [](DeviceCalibration& self, const std::string& label) {
+            Eigen::MatrixXf matrix = self.loadDevignettingMask(label);
+            return tools::image::matrix2fToNumpy(matrix);
+          },
+          py::arg("label"),
+          "Load devignetting mask corresponding to the label and return as numpy array");
 
   m.def(
       "device_calibration_from_json",

--- a/core/python/ImageDataHelper.h
+++ b/core/python/ImageDataHelper.h
@@ -37,6 +37,30 @@ inline PyArrayVariant toPyArrayVariant(const ManagedImageVariant& imageVariant);
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 // Implementation below
+inline py::array_t<float> matrix2fToNumpy(const Eigen::MatrixXf& matrix) {
+  size_t rows = matrix.rows();
+  size_t cols = matrix.cols();
+  return py::array_t<float>(
+      {rows, cols}, // shape
+      {cols * sizeof(float), sizeof(float)}, // strides
+      matrix.data() // data pointer
+  );
+}
+
+inline Eigen::MatrixXf numpyToMatrix2f(const py::array_t<float>& array) {
+  // Request a buffer descriptor from the NumPy array
+  py::buffer_info buf = array.request();
+  if (buf.ndim != 2) {
+    throw std::runtime_error("Input should be a 2D NumPy array");
+  }
+  if (buf.format != py::format_descriptor<float>::format()) {
+    throw std::runtime_error("Input should be a NumPy array of type float");
+  }
+  size_t rows = buf.shape[0];
+  size_t cols = buf.shape[1];
+  Eigen::MatrixXf matrix = Eigen::Map<Eigen::MatrixXf>(static_cast<float*>(buf.ptr), rows, cols);
+  return matrix;
+}
 
 struct PyArrayVariantVisitor {
   template <class T, int M>


### PR DESCRIPTION
Summary:
1. add template to enable compatibility for uint8_t, uint16_t, uint64_t, float single channel images.
2. use srcImage.ndim() to check channel number to enable devignetting both on gray and rgb image and follow same API design.

Please see example usage in core/examples/dataprovider_quickstart_tutorial.ipynb

Reviewed By: chpeng-fb

Differential Revision: D67369654
