### PR TITLE
{BugFix} Fixing a image H/W swapped issue in np.array.

### DIFF
--- a/projectaria_tools/utils/calibration_utils.py
+++ b/projectaria_tools/utils/calibration_utils.py
@@ -27,8 +27,9 @@ def undistort_image_and_calibration(
     input_calib_height = input_calib.get_image_size()[1]
     input_calib_focal = input_calib.get_focal_lengths()[0]
     if (
-        input_image.shape[0] != input_calib_width
-        or input_image.shape[1] != input_calib_height
+        # numpy array report matrix shape as (height, width)
+        input_image.shape[0] != input_calib_height
+        or input_image.shape[1] != input_calib_width
     ):
         raise ValueError(
             f"Input image shape {input_image.shape} does not match calibration {input_calib.get_image_size()}"


### PR DESCRIPTION
Summary:
This diff fixes a bug where `np.array` stores an image as [height, width], and our `calibration.get_image_size()` returns [width, height]. 

See https://github.com/facebookresearch/projectaria_tools/issues/106.

Reviewed By: chpeng-fb

Differential Revision: D68299181


