### PR TITLE
{Feature} C++ - Core - Add Jacobian computation in CameraProjection

### DIFF
--- a/core/calibration/camera_projections/CameraProjection.cpp
+++ b/core/calibration/camera_projections/CameraProjection.cpp
@@ -79,11 +79,12 @@ Eigen::Matrix<Scalar, 2, 1> CameraProjectionTemplated<Scalar>::getPrincipalPoint
 
 template <typename Scalar>
 Eigen::Matrix<Scalar, 2, 1> CameraProjectionTemplated<Scalar>::project(
-    const Eigen::Matrix<Scalar, 3, 1>& pointInCamera) const {
+    const Eigen::Matrix<Scalar, 3, 1>& pointInCamera,
+    Eigen::Matrix<Scalar, 2, 3>* jacobianWrtPoint) const {
   return std::visit(
       [&](auto&& projection) {
         using T = std::decay_t<decltype(projection)>;
-        return T::project(pointInCamera, projectionParams_);
+        return T::project(pointInCamera, projectionParams_, jacobianWrtPoint);
       },
       projectionVariant_);
 }

--- a/core/calibration/camera_projections/CameraProjection.h
+++ b/core/calibration/camera_projections/CameraProjection.h
@@ -67,8 +67,16 @@ struct CameraProjectionTemplated {
   /**
    * @brief projects a 3d world point in the camera space to a 2d pixel in the image space. No
    * checks performed in this process.
+   *
+   * @param pointInCamera The 3D point in camera space to be projected.
+   * @param jacobianWrtPoint Optional, if not null, will store the Jacobian of the projection
+   * with respect to the point in camera space.
+   *
+   * @return The 2D pixel coordinates of the projected point in the image space.
    */
-  Eigen::Matrix<Scalar, 2, 1> project(const Eigen::Matrix<Scalar, 3, 1>& pointInCamera) const;
+  Eigen::Matrix<Scalar, 2, 1> project(
+      const Eigen::Matrix<Scalar, 3, 1>& pointInCamera,
+      Eigen::Matrix<Scalar, 2, 3>* jacobianWrtPoint = nullptr) const;
 
   /**
    * @brief unprojects a 2d pixel in the image space to a 3d world point in homogenous coordinate.

--- a/core/calibration/camera_projections/Spherical.h
+++ b/core/calibration/camera_projections/Spherical.h
@@ -49,10 +49,15 @@ class SphericalProjection {
   //
   // Return 2-point in the image plane.
   //
-  template <class D, class DP>
+  template <class D, class DP, class DJ = Eigen::Matrix<typename D::Scalar, 2, 3>>
   static Eigen::Matrix<typename D::Scalar, 2, 1> project(
       const Eigen::MatrixBase<D>& pointOptical,
-      const Eigen::MatrixBase<DP>& params) {
+      const Eigen::MatrixBase<DP>& params,
+      Eigen::MatrixBase<DJ>* d_point = nullptr) {
+    if (d_point != nullptr) {
+      throw std::runtime_error("Jacobians not implemented in Spherical projection model");
+    }
+
     validateProjectInput<D, DP, kNumParams>();
     using T = typename D::Scalar;
     SOPHUS_ENSURE(pointOptical.z() != T(0), "z(%) must not be zero.", pointOptical.z());

--- a/core/python/DeviceCalibrationPyBind.h
+++ b/core/python/DeviceCalibrationPyBind.h
@@ -62,6 +62,7 @@ inline void declareCameraCalibration(py::module& m) {
           "project",
           &CameraProjection::project,
           py::arg("point_in_camera"),
+          py::arg("jacobian_wrt_point") = nullptr,
           "projects a 3d world point in the camera space to a 2d pixel in the image space."
           " No checks performed in this process.")
       .def(


### PR DESCRIPTION
Summary:
Add the ability to generate the jacobian of the projection with respect to the 2D pixel it projects to

When calling project, we now have the option to pass a non-owning pointer to an eigne Matrix<2,3> that represents how changes in the 3D point relate to changes in the corresponding output pixel. 

This isn't supported by the Spherical model (it's explicitly disabled in the original perception implmentation)

Differential Revision: D68807914


