### PR TITLE
{BugFix} C++ - Viewer - Add timestamp cache to avoid unnecessary thread creation / destruction.

### DIFF
--- a/tools/visualization/AriaPlayer.cpp
+++ b/tools/visualization/AriaPlayer.cpp
@@ -28,8 +28,11 @@ AriaPlayer::AriaPlayer(
 void AriaPlayer::run() {
   while (!visControl_->shouldClose_) {
     int64_t timestampNs = visControl_->timestampNs_;
-    playFromTimeNsMultiThread(timestampNs);
-    updateImagesStatic(visControl_->timestampNs_);
+    if (timestampNs != lastTimestampNs_) {
+      playFromTimeNsMultiThread(timestampNs);
+      updateImagesStatic(visControl_->timestampNs_);
+      lastTimestampNs_ = timestampNs;
+    }
   }
 }
 

--- a/tools/visualization/AriaPlayer.h
+++ b/tools/visualization/AriaPlayer.h
@@ -48,6 +48,7 @@ class AriaPlayer {
   std::shared_ptr<projectaria::tools::data_provider::VrsDataProvider> dataProvider_;
   std::shared_ptr<AriaVisualizationData> visData_;
   std::shared_ptr<AriaVisualizationControl> visControl_;
+  int64_t lastTimestampNs_ = -1;
 };
 
 std::shared_ptr<AriaPlayer> createAriaPlayer(

--- a/tools/visualization/AriaViewer.cpp
+++ b/tools/visualization/AriaViewer.cpp
@@ -310,7 +310,8 @@ void AriaViewer::updateGuiAndControl() {
 
 void AriaViewer::updateImages() {
   for (const auto& [streamId, imageView] : streamIdToPixelFrame_) {
-    if (ariaVisData_->cameraImageBufferMap_.count(streamId) == 0) {
+    if (!ariaVisData_->isDataChanged(streamId) ||
+        ariaVisData_->cameraImageBufferMap_.count(streamId) == 0) {
       continue;
     }
     auto& imageData = ariaVisData_->cameraImageBufferMap_.at(streamId);


### PR DESCRIPTION
Summary: This diff adds a `lastTimestamp` cache in `AriaPlayer` class. This can avoid threads being created / destructed under non-playing mode.

Reviewed By: danielyan86129, SeaOtocinclus

Differential Revision: D68987623


