### PR TITLE
Fix Moviepy dependancy issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -171,7 +171,7 @@ def main():
                 "plotly",
                 "scipy",
                 ## Required for vrs_to_mp4
-                "moviepy",
+                "moviepy==1.0.3",
             ]
         },
         entry_points={


### PR DESCRIPTION
Moviepy 2.0 was released in November 2024, With version 2.0, the moviepy.editor namespace simply no longer exists. 