### PR TITLE
Fix building website on newer Node versions

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -19,8 +19,8 @@
 // @ts-check
 // Note: type annotations allow type checking and IDEs autocompletion
 
-const math = require('remark-math');
-const katex = require('rehype-katex');
+import math from 'remark-math';
+import katex from 'rehype-katex';
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {


### PR DESCRIPTION
This was previously (primarily) using a version of Node where `require` still worked. Could be some combination of node & dependencies versioning at play, but at the end of the day it doesn't matter - it stopped working. These ended up being objects with `{default}` rather than the actual export (the ES module compat layer essentially).

It's 2025, we can just use `import`.