### PR TITLE
{Build} C++ - Fix minimum CMake required version

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -64,7 +64,8 @@ jobs:
         run: |
           mkdir build
           cmake -DCMAKE_BUILD_TYPE=RELEASE -S . -B build \
-            -DBUILD_UNIT_TEST=ON
+            -DBUILD_UNIT_TEST=ON \
+            -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 
       - name: C++ - Build and Test
         shell: bash

--- a/.github/workflows/build-and-test_projects.yml
+++ b/.github/workflows/build-and-test_projects.yml
@@ -84,6 +84,9 @@ jobs:
         shell: bash
         run: |
           mkdir build
-          cmake -DCMAKE_BUILD_TYPE=RELEASE -S ./ -B build -D${{ matrix.project }}=ON -DPROJECTARIA_TOOLS_BUILD_PROJECTS=ON
+          cmake -DCMAKE_BUILD_TYPE=RELEASE -S ./ \
+            -B build -D${{ matrix.project }}=ON \
+            -DPROJECTARIA_TOOLS_BUILD_PROJECTS=ON  \
+            -DCMAKE_POLICY_VERSION_MINIMUM=3.5
           cd build
           make -j8

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ class CMakeBuild(build_ext):
             "-DPROJECTARIA_TOOLS_BUILD_PROJECTS_ADT=ON",
             "-DPROJECTARIA_TOOLS_BUILD_PROJECTS_ASE=ON",
             "-DPROJECTARIA_TOOLS_BUILD_PROJECTS_AEA=ON",
+            "-DCMAKE_POLICY_VERSION_MINIMUM=3.5",
         ]
         build_args = []
         # Adding CMake arguments set as environment variable


### PR DESCRIPTION
Summary:
Many modules are using cmake_minimum_required and so are not configuring with recent CMake by default.
We are adding here a new minimum version in the cmake configure command line to match a more recent CMake version.

Differential Revision: D72274842


