### PR TITLE
{Feature} Image - copy to pixel frame util - unit test

### DIFF
--- a/core/data_provider/RecordReaderInterface.cpp
+++ b/core/data_provider/RecordReaderInterface.cpp
@@ -407,4 +407,19 @@ MotionData RecordReaderInterface::getLastCachedMagnetometerData(const vrs::Strea
   magnetometerData.magTesla[2] = magnetometerData.magTesla[2] * 1e-6;
   return magnetometerData;
 }
+
+uint32_t RecordReaderInterface::getRgbIspTuningVersion() const {
+  if (fileTags_.empty()) {
+    return 0;
+  }
+  std::string tempKey = "rgb_isp_tuning_version";
+  auto it = fileTags_.find(tempKey);
+  if (it != fileTags_.end()) {
+    auto metadataJson = nlohmann::json::parse(it->second);
+    if (metadataJson.contains(tempKey)) {
+      return static_cast<uint32_t>(metadataJson[tempKey]);
+    }
+  }
+  return 0;
+}
 } // namespace projectaria::tools::data_provider

--- a/core/data_provider/RecordReaderInterface.h
+++ b/core/data_provider/RecordReaderInterface.h
@@ -75,6 +75,9 @@ class RecordReaderInterface {
   MotionData getLastCachedMagnetometerData(const vrs::StreamId& streamId);
 
   void setReadImageContent(vrs::StreamId streamId, bool readContent);
+  // ISP tuning version for RGB images, 0: output image is color corrected, 1: output image is not
+  // color correctted.
+  [[nodiscard]] uint32_t getRgbIspTuningVersion() const;
 
   [[nodiscard]] std::optional<MetadataTimeSyncMode> getTimeSyncMode() const;
 

--- a/core/data_provider/SensorData.h
+++ b/core/data_provider/SensorData.h
@@ -130,10 +130,15 @@ class SensorData {
 
  private:
   vrs::StreamId streamId_;
+
+ protected:
   SensorDataVariant dataVariant_;
+
+ private:
   SensorDataType sensorDataType_;
   int64_t recordInfoTimeNs_;
   std::map<TimeSyncMode, int64_t> timeSyncTimeNs_;
+  friend class VrsDataProvider;
 
   // get timestamp in device or host time domain
   int64_t getDeviceTime() const;

--- a/core/data_provider/VrsDataProvider.cpp
+++ b/core/data_provider/VrsDataProvider.cpp
@@ -538,4 +538,14 @@ void VrsDataProvider::assertStreamIsType(const vrs::StreamId& streamId, SensorDa
       checkStreamIsType(streamId, type),
       fmt::format("StreamId {} is not {} type streamId", streamId.getName(), getName(type)));
 }
+
+void VrsDataProvider::setDevignettingMaskFolderPath(const std::string& maskFolderPath) {
+  checkAndThrow(maybeDeviceCalib_.has_value(), "Device calibration is not found");
+  maybeDeviceCalib_->setDevignettingMaskFolderPath(maskFolderPath);
+}
+
+Eigen::MatrixXf VrsDataProvider::loadDevignettingMask(const std::string& label) {
+  checkAndThrow(maybeDeviceCalib_.has_value(), "Device calibration is not found");
+  return maybeDeviceCalib_->loadDevignettingMask(label);
+}
 } // namespace projectaria::tools::data_provider

--- a/core/data_provider/VrsDataProvider.cpp
+++ b/core/data_provider/VrsDataProvider.cpp
@@ -35,7 +35,9 @@ VrsDataProvider::VrsDataProvider(
       timeQuery_(std::make_shared<TimestampIndexMapper>(interface_)),
       timeSyncMapper_(timeSyncMapper),
       streamIdLabelMapper_(streamIdLabelMapper),
-      maybeDeviceCalib_(maybeDeviceCalib) {}
+      maybeDeviceCalib_(maybeDeviceCalib) {
+  rgbIspTuningVersion_ = interface_ ? interface_->getRgbIspTuningVersion() : 0;
+}
 
 SensorDataType VrsDataProvider::getSensorDataType(const vrs::StreamId& streamId) const {
   return interface_->getSensorDataType(streamId);

--- a/core/data_provider/VrsDataProvider.cpp
+++ b/core/data_provider/VrsDataProvider.cpp
@@ -218,6 +218,10 @@ ImageDataAndRecord VrsDataProvider::getImageDataByIndex(
   }
 }
 
+void VrsDataProvider::setDevignetting(bool applyDevignetting) {
+  applyDevignetting_ = applyDevignetting;
+}
+
 MotionData VrsDataProvider::getImuDataByIndex(const vrs::StreamId& streamId, const int index) {
   assertStreamIsActive(streamId);
   assertStreamIsType(streamId, SensorDataType::Imu);
@@ -547,5 +551,9 @@ void VrsDataProvider::setDevignettingMaskFolderPath(const std::string& maskFolde
 Eigen::MatrixXf VrsDataProvider::loadDevignettingMask(const std::string& label) {
   checkAndThrow(maybeDeviceCalib_.has_value(), "Device calibration is not found");
   return maybeDeviceCalib_->loadDevignettingMask(label);
+}
+
+void VrsDataProvider::setColorCorrection(bool applyColorCorrection) {
+  applyColorCorrection_ = applyColorCorrection;
 }
 } // namespace projectaria::tools::data_provider

--- a/core/data_provider/VrsDataProvider.h
+++ b/core/data_provider/VrsDataProvider.h
@@ -423,6 +423,13 @@ class VrsDataProvider {
       const std::optional<calibration::DeviceCalibration>& maybeDeviceCalib);
 
   virtual ~VrsDataProvider() = default; // Add a virtual destructor
+
+  /**
+   * @brief turn on/off devignetting
+   * @param applyDevignetting True to apply devignetting, false to skip devignetting
+   * @return void
+   */
+  void setDevignetting(bool applyDevignetting);
   /**
    * @brief set the folder path of the vignetting mask.
    * @param maskFolderPath The folder path of the vignetting mask.
@@ -438,6 +445,12 @@ class VrsDataProvider {
    * @return Vignetting mask in Eigen::MatrixXf format.
    */
   Eigen::MatrixXf loadDevignettingMask(const std::string& label);
+  /**
+   * @brief turn on/off color correction
+   * @param applyColorCorrection True to apply color correction, false to skip color correction
+   * @return void
+   */
+  void setColorCorrection(bool applyColorCorrection);
 
  private:
   // assert if a streamId is not active
@@ -457,6 +470,8 @@ class VrsDataProvider {
   // in order to keep the iterator alive
   std::pair<SensorDataIterator, SensorDataIterator> dataIterPair_;
   uint32_t rgbIspTuningVersion_ = 0;
+  bool applyDevignetting_ = false;
+  bool applyColorCorrection_ = false;
 };
 
 } // namespace projectaria::tools::data_provider

--- a/core/data_provider/VrsDataProvider.h
+++ b/core/data_provider/VrsDataProvider.h
@@ -423,6 +423,21 @@ class VrsDataProvider {
       const std::optional<calibration::DeviceCalibration>& maybeDeviceCalib);
 
   virtual ~VrsDataProvider() = default; // Add a virtual destructor
+  /**
+   * @brief set the folder path of the vignetting mask.
+   * @param maskFolderPath The folder path of the vignetting mask.
+   * @return void
+   */
+  void setDevignettingMaskFolderPath(const std::string& maskFolderPath);
+  /**
+   * @brief Get devignetting mask based on label and image size.
+   * devignetting_mask = 1/vignetting_mask
+   * devignetted_image = devignetting_mask * original_image
+   * @param label The label of the camera
+   * now supporting "camera-slam-left", "camera-slam-right", "camera-rgb"
+   * @return Vignetting mask in Eigen::MatrixXf format.
+   */
+  Eigen::MatrixXf loadDevignettingMask(const std::string& label);
 
  private:
   // assert if a streamId is not active

--- a/core/data_provider/VrsDataProvider.h
+++ b/core/data_provider/VrsDataProvider.h
@@ -441,6 +441,7 @@ class VrsDataProvider {
   // pybind11 requires variable to attach to VrsDataProvider class
   // in order to keep the iterator alive
   std::pair<SensorDataIterator, SensorDataIterator> dataIterPair_;
+  uint32_t rgbIspTuningVersion_ = 0;
 };
 
 } // namespace projectaria::tools::data_provider

--- a/core/image/CopyToPixelFrame.cpp
+++ b/core/image/CopyToPixelFrame.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "CopyToPixelFrame.h"
+
+namespace projectaria::tools::image {
+void copyToPixelFrame(
+    const projectaria::tools::image::ManagedImageVariant& srcImage,
+    vrs::utils::PixelFrame& pixelFrame) {
+  size_t dataSize = pixelFrame.getBuffer().size();
+  uint8_t* pixelFrameData = pixelFrame.wdata();
+  std::visit(
+      [&](const auto& img) {
+        if (img.sizeBytes() != dataSize) {
+          throw std::runtime_error("Size mismatch between ManagedImageVariant and PixelFrame");
+        }
+        std::memcpy(pixelFrameData, img.data(), dataSize);
+      },
+      srcImage);
+}
+} // namespace projectaria::tools::image

--- a/core/image/CopyToPixelFrame.h
+++ b/core/image/CopyToPixelFrame.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <vrs/utils/PixelFrame.h>
+#include "ImageVariant.h"
+
+namespace projectaria::tools::image {
+void copyToPixelFrame(
+    const projectaria::tools::image::ManagedImageVariant& srcImage,
+    vrs::utils::PixelFrame& pixelFrame);
+} // namespace projectaria::tools::image

--- a/core/image/test/CopyToPixelFrameTest.cpp
+++ b/core/image/test/CopyToPixelFrameTest.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <image/CopyToPixelFrame.h>
+#include <image/ImageVariant.h>
+#include <vrs/utils/PixelFrame.h>
+using namespace projectaria::tools::image;
+TEST(ManagedImage, CopyToPixelFrameTest) {
+  // Unit test for copyToPixelFrame function
+  constexpr int rows = 10;
+  constexpr int cols = 9;
+  ManagedImage<uint8_t> image(cols, rows);
+  for (int row = 0; row < rows; row++) {
+    for (int col = 0; col < cols; col++) {
+      image(col, row) = 42;
+    }
+  }
+  ManagedImageVariant managedImageVariant = std::move(image);
+  // Create a PixelFrame with the same size
+  vrs::utils::PixelFrame pixelFrame(vrs::PixelFormat::GREY8, cols, rows, cols);
+  vrs::utils::PixelFrame originalPixelFrame = pixelFrame;
+  copyToPixelFrame(managedImageVariant, pixelFrame);
+
+  // Verify that the data in PixelFrame matches the data from ManagedImage
+  const uint8_t* pixelFrameData = pixelFrame.data<uint8_t>();
+  for (size_t i = 0; i < pixelFrame.getBuffer().size(); ++i) {
+    EXPECT_EQ(pixelFrameData[i], 42);
+  }
+
+  // Compare metadata of original and modified PixelFrame
+  EXPECT_EQ(originalPixelFrame.getWidth(), pixelFrame.getWidth());
+  EXPECT_EQ(originalPixelFrame.getHeight(), pixelFrame.getHeight());
+  EXPECT_EQ(originalPixelFrame.getStride(), pixelFrame.getStride());
+  EXPECT_EQ(originalPixelFrame.getPixelFormat(), pixelFrame.getPixelFormat());
+}

--- a/core/python/VrsDataProviderPyBind.h
+++ b/core/python/VrsDataProviderPyBind.h
@@ -21,6 +21,7 @@
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+#include "ImageDataHelper.h"
 #include "SensorDataSequence.h"
 
 #define DEFAULT_LOG_CHANNEL "VrsDataProvider"
@@ -519,7 +520,20 @@ inline void declareVrsDataProvider(py::module& m) {
           py::arg("stream_id"),
           py::arg("time_ns"),
           py::arg("time_domain"),
-          py::arg("time_query_options") = TimeQueryOptions::Before);
+          py::arg("time_query_options") = TimeQueryOptions::Before)
+      .def(
+          "set_devignetting_mask_folder_path",
+          &VrsDataProvider::setDevignettingMaskFolderPath,
+          py::arg("mask_folder_path"),
+          "Set the devignetting mask folder path.")
+      .def(
+          "load_devignetting_mask",
+          [](VrsDataProvider& self, const std::string& label) {
+            Eigen::MatrixXf matrix = self.loadDevignettingMask(label);
+            return tools::image::matrix2fToNumpy(matrix);
+          },
+          py::arg("label"),
+          "Load devignetting mask corresponding to the label and return as numpy array");
 }
 } // namespace
 

--- a/core/python/VrsDataProviderPyBind.h
+++ b/core/python/VrsDataProviderPyBind.h
@@ -522,6 +522,16 @@ inline void declareVrsDataProvider(py::module& m) {
           py::arg("time_domain"),
           py::arg("time_query_options") = TimeQueryOptions::Before)
       .def(
+          "set_devignetting",
+          &VrsDataProvider::setDevignetting,
+          py::arg("apply_devignetting"),
+          "Turn on/off devignetting. Pass True to apply devignetting, False to skip it.")
+      .def(
+          "set_color_correction",
+          &VrsDataProvider::setColorCorrection,
+          py::arg("apply_color_correction"),
+          "Turn on/off color correction. Pass True to apply color correction, False to skip it.")
+      .def(
           "set_devignetting_mask_folder_path",
           &VrsDataProvider::setDevignettingMaskFolderPath,
           py::arg("mask_folder_path"),


### PR DESCRIPTION
Summary:
Unit Test for `copyToPixelFrame` Function:
1. Create a `ManagedImageVariant` and a `PixelFrame` with identical dimensions.
2. Copy data from the `ManagedImageVariant` to the `PixelFrame`.
3. Verify the accuracy of the data in the `PixelFrame` and ensure the metadata remains unchanged.

Reviewed By: hxtang

Differential Revision: D70753333
