### PR TITLE
{feature} Devignetting - 3 channels masks - Devignetting

### DIFF
--- a/core/image/utility/Devignetting.h
+++ b/core/image/utility/Devignetting.h
@@ -27,5 +27,5 @@ namespace projectaria::tools::image {
  */
 ManagedImageVariant devignetting(
     const ImageVariant& srcImage,
-    const Eigen::MatrixXf& devignettingMask);
+    const ManagedImage3F32& devignettingMask);
 } // namespace projectaria::tools::image


### PR DESCRIPTION
Summary:
This update modifies the input for the devignetting function, replacing Eigen::MatrixXf with ManagedImage3F32.

To avoid differentiate the 1 & 3 channels mask, both RGB and SLAM masks binary saved three channel infor. But every channel for SLAM image is the same.

Reviewed By: chpeng-fb

Differential Revision: D71150778
