### PR TITLE
{Feature} Devignetting - 3 channels masks - DeviceCalibration

### DIFF
--- a/core/calibration/DeviceCalibration.h
+++ b/core/calibration/DeviceCalibration.h
@@ -18,6 +18,7 @@
 
 #include <calibration/DeviceCadExtrinsics.h>
 #include <calibration/SensorCalibration.h>
+#include <image/ImageVariant.h>
 #include <sophus/se3.hpp>
 #include <map>
 #include <optional>
@@ -168,7 +169,9 @@ class DeviceCalibration {
    * now supporting "camera-slam-left", "camera-slam-right", "camera-rgb"
    * @return Vignetting mask in Eigen::MatrixXf format.
    */
-  Eigen::MatrixXf loadDevignettingMask(const std::string& label);
+  projectaria::tools::image::ManagedImage3F32 loadDevignettingMask(
+      const std::string& label,
+      uint32_t rgbIspTuningVersion = 0);
 
  private:
   friend void tryCropAndScaleCameraCalibration(

--- a/core/image/utility/Devignetting.h
+++ b/core/image/utility/Devignetting.h
@@ -27,5 +27,5 @@ namespace projectaria::tools::image {
  */
 ManagedImageVariant devignetting(
     const ImageVariant& srcImage,
-    const Eigen::MatrixXf& devignettingMask);
+    const ManagedImage3F32& devignettingMask);
 } // namespace projectaria::tools::image


### PR DESCRIPTION
Summary:
This update modifies the input for the loadDevignettingMask function in DeviceCalibration, replacing Eigen::MatrixXf with ManagedImage3F32.
To avoid differentiate the 1 & 3 channels mask, both RGB and SLAM masks binary saved three channel info. But every channel for SLAM image is the same.

Reviewed By: chpeng-fb

Differential Revision: D71150795
