### PR TITLE
{Feature} Devignetting - 3 channels masks - VrsDataProvider

### DIFF
--- a/core/calibration/CMakeLists.txt
+++ b/core/calibration/CMakeLists.txt
@@ -34,4 +34,4 @@ target_link_libraries(device_cad_extrinsics PUBLIC vrs_logging Eigen3::Eigen Sop
 
 add_library(device_calibration DeviceCalibration.cpp DeviceCalibration.h)
 target_include_directories(device_calibration PUBLIC "../")
-target_link_libraries(device_calibration PUBLIC device_cad_extrinsics sensor_calibration Sophus::Sophus)
+target_link_libraries(device_calibration PUBLIC device_cad_extrinsics sensor_calibration Sophus::Sophus image)

--- a/core/calibration/DeviceCalibration.h
+++ b/core/calibration/DeviceCalibration.h
@@ -18,6 +18,7 @@
 
 #include <calibration/DeviceCadExtrinsics.h>
 #include <calibration/SensorCalibration.h>
+#include <image/ImageVariant.h>
 #include <sophus/se3.hpp>
 #include <map>
 #include <optional>
@@ -168,7 +169,9 @@ class DeviceCalibration {
    * now supporting "camera-slam-left", "camera-slam-right", "camera-rgb"
    * @return Vignetting mask in Eigen::MatrixXf format.
    */
-  Eigen::MatrixXf loadDevignettingMask(const std::string& label);
+  projectaria::tools::image::ManagedImage3F32 loadDevignettingMask(
+      const std::string& label,
+      uint32_t rgbIspTuningVersion = 0);
 
  private:
   friend void tryCropAndScaleCameraCalibration(

--- a/core/data_provider/VrsDataProvider.h
+++ b/core/data_provider/VrsDataProvider.h
@@ -444,7 +444,7 @@ class VrsDataProvider {
    * now supporting "camera-slam-left", "camera-slam-right", "camera-rgb"
    * @return Vignetting mask in Eigen::MatrixXf format.
    */
-  Eigen::MatrixXf loadDevignettingMask(const std::string& label);
+  projectaria::tools::image::ManagedImage3F32 loadDevignettingMask(const std::string& label);
   /**
    * @brief turn on/off color correction
    * @param applyColorCorrection True to apply color correction, false to skip color correction
@@ -485,7 +485,7 @@ class VrsDataProvider {
   uint32_t rgbIspTuningVersion_ = 0;
   bool applyDevignetting_ = false;
   bool applyColorCorrection_ = false;
-  std::unordered_map<std::string, Eigen::MatrixXf> devignettingMasks_;
+  std::unordered_map<std::string, std::shared_ptr<image::ManagedImage3F32>> devignettingMasks_;
 };
 
 } // namespace projectaria::tools::data_provider

--- a/core/examples/dataprovider_quickstart_tutorial.ipynb
+++ b/core/examples/dataprovider_quickstart_tutorial.ipynb
@@ -645,13 +645,12 @@
     "|- rgb_half_devignetting_mask.bin\n",
     "|- rgb_full_devignetting_mask.bin\n",
     "```\n",
-    "2. set devignetting mask folder path with the local aria camera devignetting masks folder path.\n",
+    "2. Turn on devignetting. Set devignetting mask folder path with the local aria camera devignetting masks folder path.\n",
+    "   `set_devignetting(True)`\n",
     "   `mask_folder_path = \"aria_camera_devignetting_masks\"`\n",
     "   `set_devignetting_mask_folder_path(mask_folder_path)`\n",
-    "4. load mask by passing camera label, now supporting \"camera-rgb\", \"camera-slam-left\" and \"camera-slam-right\".\n",
-    "   `load_devignetting_mask(label)`\n",
-    "5. apply devignetting to source image.\n",
-    "   `devignetting(src_image, devignetting_mask)`"
+    "3. The image data from `get_image_data_by_index` will be devignetted. \n",
+    "4. (Optional) If you don't want to devignetting feature, turn off by calling `set_devignetting(False)`"
    ]
   },
   {
@@ -697,18 +696,30 @@
    "id": "62f31e06-a088-42ad-9500-c5157c871205",
    "metadata": {},
    "source": [
-    "## Step 2: Set devignetting mask folder path with the local folder path"
+    "## Step 2: Turn on devignetting and set devignetting mask folder path"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d373b069-46bd-4855-b402-a6f9aa61fed4",
+   "id": "5e0edbd5-a036-48f5-9f50-cc32490aab3e",
    "metadata": {},
    "outputs": [],
    "source": [
-    "deviceCalib = provider.get_device_calibration()\n",
-    "deviceCalib.set_devignetting_mask_folder_path(devignetting_mask_folder_path)"
+    "# save source image for comparison\n",
+    "stream_id = provider.get_stream_id_from_label(\"camera-rgb\")\n",
+    "src_image_array = provider.get_image_data_by_index(stream_id, 0)[0].to_numpy_array()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "186e9e0d-93f0-472e-bb56-ea6551eeda8d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "provider.set_devignetting(True)\n",
+    "provider.set_devignetting_mask_folder_path(devignetting_mask_folder_path)"
    ]
   },
   {
@@ -716,7 +727,7 @@
    "id": "5a69ed80-ddbb-48f5-92d5-6b06e0c393a4",
    "metadata": {},
    "source": [
-    "## Step 3 & 4: load mask and apply devignetting to source image."
+    "## Step 3: Retrieve Image from stream"
    ]
   },
   {
@@ -726,21 +737,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "stream_id = provider.get_stream_id_from_label(\"camera-rgb\")\n",
-    "image_data = provider.get_image_data_by_index(stream_id, 0)\n",
-    "src_image_array = image_data[0].to_numpy_array()\n",
-    "\n",
-    "# load devignetting mask by feeding camera label\n",
-    "devignetting_mask = deviceCalib.load_devignetting_mask(\"camera-rgb\")\n",
-    "\n",
-    "# apply devignetting to source image\n",
-    "devignetted_image_array = calibration.devignetting(\n",
-    "            src_image_array, devignetting_mask\n",
-    "        ).astype(np.uint8)\n",
+    "devignetted_image_array = provider.get_image_data_by_index(stream_id, 0)[0].to_numpy_array()\n",
     "\n",
     "# visualize input and results\n",
     "plt.figure()\n",
-    "fig, axes = plt.subplots(1, 2, figsize=(12, 5))\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(12, 6))\n",
     "fig.suptitle(f\"Image devignetting (camera-rgb)\")\n",
     "\n",
     "axes[0].imshow(src_image_array, vmin=0, vmax=255)\n",
@@ -830,7 +831,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.7"
+   "version": "3.12.5"
   }
  },
  "nbformat": 4,

--- a/core/examples/dataprovider_quickstart_tutorial.ipynb
+++ b/core/examples/dataprovider_quickstart_tutorial.ipynb
@@ -761,7 +761,9 @@
     "Videos and images captured with earlier versions of the Aria OS may exhibit color distortion due to inconsistent gamma curves and unconventional color temperatures. This can result in colors appearing inconsistent across images and overly blue.\n",
     "This issue has been resolved in the new OS update V1.13. For images and videos captured before this update, we offer a Color Correction API to address the distortion. The images will be corrected to a reference color temperature of 5000K. \n",
     "\n",
-    "Below, we demonstrate how to apply color correction:"
+    "Below, we demonstrate how to apply color correction: \n",
+    "1. set `set_color_correction` with True, default value is False\n",
+    "2. The output from `provider.get_image_data_by_index` would be color corrected. "
    ]
   },
   {
@@ -771,21 +773,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "corrected_image_array = calibration.color_correct(\n",
-    "            src_image_array\n",
-    "        ).astype(np.uint8)\n",
+    "provider.set_color_correction(True)\n",
+    "provider.set_devignetting(False) # turn off devignetting since we turned on it on the previous section.\n",
+    "color_corrected_image_array = provider.get_image_data_by_index(stream_id, 0)[0].to_numpy_array()\n",
     "\n",
     "# visualize input and results\n",
     "plt.figure()\n",
-    "fig, axes = plt.subplots(1, 2, figsize=(12, 5))\n",
-    "fig.suptitle(f\"Correct color distortion and set temperature at 5000K\")\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(12, 6))\n",
+    "fig.suptitle(f\"Color Correction\")\n",
     "\n",
     "axes[0].imshow(src_image_array, vmin=0, vmax=255)\n",
-    "axes[0].title.set_text(f\"old image\")\n",
-    "axes[1].imshow(corrected_image_array, vmin=0, vmax=255)\n",
-    "axes[1].title.set_text(f\"corrected image\")\n",
+    "axes[0].title.set_text(f\"original image\")\n",
+    "axes[1].imshow(color_corrected_image_array, vmin=0, vmax=255)\n",
+    "axes[1].title.set_text(f\"color corrected image\")\n",
     "\n",
-    "plt.show()\n"
+    "plt.show()"
    ]
   }
  ],

--- a/core/image/utility/Devignetting.h
+++ b/core/image/utility/Devignetting.h
@@ -27,5 +27,5 @@ namespace projectaria::tools::image {
  */
 ManagedImageVariant devignetting(
     const ImageVariant& srcImage,
-    const Eigen::MatrixXf& devignettingMask);
+    const ManagedImage3F32& devignettingMask);
 } // namespace projectaria::tools::image

--- a/core/python/VrsDataProviderPyBind.h
+++ b/core/python/VrsDataProviderPyBind.h
@@ -539,8 +539,8 @@ inline void declareVrsDataProvider(py::module& m) {
       .def(
           "load_devignetting_mask",
           [](VrsDataProvider& self, const std::string& label) {
-            Eigen::MatrixXf matrix = self.loadDevignettingMask(label);
-            return tools::image::matrix2fToNumpy(matrix);
+            projectaria::tools::image::ManagedImage3F32 matrix = self.loadDevignettingMask(label);
+            return image::toPyArrayVariant(matrix);
           },
           py::arg("label"),
           "Load devignetting mask corresponding to the label and return as numpy array");

--- a/website/docs/data_utilities/advanced_code_snippets/image_utilities.mdx
+++ b/website/docs/data_utilities/advanced_code_snippets/image_utilities.mdx
@@ -154,42 +154,42 @@ auto ray = pinholeCW90.getT_Device_Camera() * pinholeCW90.projectNoChecks(textPi
 
 ## Image devignetting
 
-Devignetting corrects uneven lighting, enhancing image uniformity and clarity. We provide devignetting for camera-rgb full size image [2880, 2880], camera-rgb half size image[1408, 1408] and slam iamge [640, 480].
-1. Download devignetting masks from [Link](https://www.projectaria.com/async/sample/download/?bucket=core&filename=aria_devignetting_masks.zip)
-2. Unzip to local folder. The folder should follow the structure below:
+Devignetting corrects uneven lighting, enhancing image uniformity and clarity. We provide devignetting for camera-rgb full size image [2880, 2880], camera-rgb half size image[1408, 1408] and slam image [640, 480].
+1. Download [Aria devignetting masks](https://www.projectaria.com/async/sample/download/?bucket=core&filename=aria_devignetting_masks.zip) containing following files:
 
 ```
-aria_camera_devignetting_masks
+aria_devignetting_masks
 |- slam_devignetting_mask.bin
 |- rgb_half_devignetting_mask.bin
 |- rgb_full_devignetting_mask.bin
 ```
-
-3. set devignetting mask folder path with local folder.
-4. load mask by passing camera label, now supporting "camera-rgb", "camera-slam-left" and "camera-slam-right"
-5. apply devignetting to source image.
+2. Turn on devignetting. Set devignetting mask folder path with the local aria camera devignetting masks folder path.
+   ```python
+   set_devignetting(True)
+   mask_folder_path = "aria_camera_devignetting_masks"
+   set_devignetting_mask_folder_path(mask_folder_path)
+   ```
+3. The image data from `get_image_data_by_index` will be devignetted.
+4. (Optional) If you don't want to devignetting feature, turn off by calling `set_devignetting(False)`
 
 ```mdx-code-block
 <Tabs groupId="programming-language">
 <TabItem value="python" label="Python">
 ```
 ```python
-from projectaria_tools.core import data_provider, calibration, image
+from projectaria_tools.core import data_provider
 camera_label = "camera-rgb"
-devignetting_mask_folder_path = <FOLDER_PATH_CONTAINING_DEVIGNETTING_MASK>
-device_calib = provider.get_device_calibration()
 stream_id = provider.get_stream_id_from_label(camera_label)
-raw_image = provider.get_image_data_by_index(stream_id, 0)[0].to_numpy_array()
 
-# set devignetting mask with local folder path
-device_calib.set_devignetting_mask_folder_path(devignetting_mask_folder_path)
+# set devignetting mask path
+devignetting_mask_folder_path = <FOLDER_PATH_CONTAINING_DEVIGNETTING_MASK>
+provider.set_devignetting_mask_folder_path(devignetting_mask_folder_path)
 
-# load devignetting_mask by camera label
-devignetting_mask = device_calib.load_devignetting_mask(camera_label)
+# turn on devignetting
+provider.set_devignetting(True)
 
-# apply devignetting to source image
-devigneted_image = calibration.devignetting(raw_image, devignetting_mask)
-
+# the output image from get_image_data_by_index will be devignetted
+devignetted_image = provider.get_image_data_by_index(stream_id, 0)
 ```
 ```mdx-code-block
 </TabItem>
@@ -197,23 +197,20 @@ devigneted_image = calibration.devignetting(raw_image, devignetting_mask)
 ```
 ```cpp
 #include <dataprovider/VrsDataProvider.h>
-#include <image/utility/Devignetting.h>
 
 std::string cameraLabel = "camera-rgb";
-std::string devignettingMaskFolderPath = <FOLDER_PATH_CONTAINING_DEVIGNETTING_MASK>;
-auto deviceCalib = provider->getDeviceCalibration();
 vrs::StreamId streamId = provider->getStreamIdFromLabel(cameraLabel);
-auto imageData = provider->getImageDataByIndex(streamId, 0);
 
-// set devignetting mask with local folder path
-deviceCalib.SetDevignettingMaskFolderPath(devignettingMaskFolderPath);
+std::string devignettingMaskFolderPath = <FOLDER_PATH_CONTAINING_DEVIGNETTING_MASK>;
 
-// load devignetting_mask by camera label
-Eigen::MatrixXf devignettingMask = deviceCalib.loadDevignettingMask(cameraLabel);
+// set devignetting mask path
+provider.setDevignettingMaskFolderPath(devignettingMaskFolderPath);
 
-// apply devignetting to source image
-auto devignettedImage = devignetting(imageData.first.imageVariant(), devignettingMask);
+// turn on devignetting
+provider.setDevignetting(true);
 
+// the output image from getImageDataByIndex will be devignetted
+ImageDataAndRecord imageDataAndRecord = provider.getImageDataByIndex(streamId, 0);
 ```
 ```mdx-code-block
 </TabItem>


### PR DESCRIPTION
Summary:
1. This update modifies the devignetting mask used in VrsDataProvider, replacing Eigen::MatrixXf with ManagedImage3F32.
2. Fixed bugs for streamId.getTypeName() to correct type name.

Reviewed By: YLouWashU

Differential Revision: D71150807
