### PR TITLE
{Build} Update CI for python wheels to react to GitHub infra change

### DIFF
--- a/.github/workflows/build-wheels-and-deploy.yml
+++ b/.github/workflows/build-wheels-and-deploy.yml
@@ -29,8 +29,8 @@ jobs:
           python-version: 3.11
       - name: Upgrade pip and python packages
         run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install cibuildwheel==2.17.0 pybind11-stubgen==1.1
+          python -m pip install --upgrade pip
+          python -m pip install cibuildwheel==2.17.0 pybind11-stubgen==1.1
       - name: Install dependencies
         shell: bash
         run: |
@@ -61,7 +61,7 @@ jobs:
           rm -rf build
       - name: Generate stubs & Include stubs in python package
         run: |
-          python3 generate_stubs.py
+          python generate_stubs.py
           cp -r projectaria_tools-stubs/projectaria_tools .
       - uses: actions/upload-artifact@v4
         with:
@@ -116,13 +116,13 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Upgrade pip and python packages
         run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install cibuildwheel==2.17.0
+          python -m pip install --upgrade pip
+          python -m pip install cibuildwheel==2.17.0
       - name: Build wheels for CPython
         if: matrix.os == 'macos-14'
         shell: bash
         run: |
-          CMAKE_BUILD_PARALLEL_LEVEL=4 python3 -m cibuildwheel --output-dir dist
+          CMAKE_BUILD_PARALLEL_LEVEL=4 python -m cibuildwheel --output-dir dist
         env:
           CIBW_BUILD_VERBOSITY: 3
           CIBW_BUILD: ${{ matrix.cibw_build }}
@@ -132,7 +132,7 @@ jobs:
         if: ${{ (matrix.os == 'macos-13') || (matrix.os == 'ubuntu-22.04') }}
         shell: bash
         run: |
-          CMAKE_BUILD_PARALLEL_LEVEL=4 python3 -m cibuildwheel --output-dir dist
+          CMAKE_BUILD_PARALLEL_LEVEL=4 python -m cibuildwheel --output-dir dist
         env:
           CIBW_BUILD_VERBOSITY: 3
           CIBW_BUILD: ${{ matrix.cibw_build }}
@@ -142,7 +142,7 @@ jobs:
         if: matrix.os == 'windows-2022'
         shell: bash
         run: |
-          python3 -m cibuildwheel --output-dir dist
+          python -m cibuildwheel --output-dir dist
         env:
           CIBW_BUILD_VERBOSITY: 3
           CIBW_BUILD: ${{ matrix.cibw_build }}
@@ -157,11 +157,11 @@ jobs:
         shell: bash
         run: |
           # Install wheel
-          python3 -m pip install dist/*.whl
+          python -m pip install dist/*.whl
           # Run Python unit tests
           export TEST_FOLDER="./data/"
-          python3 -m unittest core/python/test/corePyBindTest.py
-          python3 -m unittest core/python/test/mpsPyBindTest.py
+          python -m unittest core/python/test/corePyBindTest.py
+          python -m unittest core/python/test/mpsPyBindTest.py
 
   publish-to-pypi:
     name: Publish to Pypi

--- a/core/python/CMakeLists.txt
+++ b/core/python/CMakeLists.txt
@@ -19,6 +19,9 @@ FetchContent_Declare(
     GIT_REPOSITORY https://github.com/pybind/pybind11.git
     GIT_TAG master
 )
+# We are assuming here that python has been found by CMake already
+# so it avoid to make pybind11/CMake & CIBUILDWHEEL to use different python versions
+set(PYBIND11_FINDPYTHON OFF)
 FetchContent_MakeAvailable(pybind11)
 
 add_subdirectory(${pybind11_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}/pybind)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,12 +54,16 @@ environment = {"CMAKE_ARGS"="-DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 -DCMAKE_C_COMPI
 # To ensure we have a fast build we:
 # - are editing x64-windows-static.cmake to build RELEASE only artifacts
 # - build only the required boost dependencies (building all boost is slow)
+#
+# We use VCPKG with a commit HASH containing the fix for CMake 4.0 see https://github.com/microsoft/vcpkg/issues/44507
+# We will update to the next available release tag once it is available
 ##
 [tool.cibuildwheel.windows]
 environment = {"CMAKE_GENERATOR"="Visual Studio 17 2022"}
 before-build = [
-"if not exist \"vcpkg\" git clone --branch 2024.08.23 https://github.com/microsoft/vcpkg.git",
+"git clone https://github.com/microsoft/vcpkg.git",
 "cd vcpkg",
+"git checkout 0bde25d4ffc4349ac70a8c22615203eb1201aa4a",
 "findstr /c:\"set(VCPKG_BUILD_TYPE release)\" triplets\\x64-windows-static.cmake || echo set(VCPKG_BUILD_TYPE release) >> triplets\\x64-windows-static.cmake",
 "bootstrap-vcpkg.bat -disableMetrics",
 "vcpkg update",


### PR DESCRIPTION
Summary:
Latest GitHub runner are now using CMake 4 and our windows pipeline for buil-wheels-and-deploy was broken.

We are here fixing the build:
- xxhash was not building
  - we updated VCPKG to a more recent version, so we can now have a xxhash project compatible with CMake 4.0 (see https://github.com/microsoft/vcpkg/issues/44507)

- cibuildwheel/cmake/pybind11 on windows were mixing python framework versions.
  - we are now relying only on CMake to find python and not enabling pybind11 to locate python (i.e. cmake was taking the right python version, by pybind was always taking python 3.11 whatever the cibuildwheel configuration that was set) (see https://pybind11.readthedocs.io/en/stable/compiling.html)

- we are changing the python3 to python, since we are already setting the python config by using `actions/setup-python@v5`

Reviewed By: hxtang

Differential Revision: D72427453


