### PR TITLE
{Build} GitHub CI - remove apt-get upgrade

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -27,7 +27,6 @@ jobs:
           if [ "$RUNNER_OS" == "Linux" ]; then
               # Update & upgrade package lists
               sudo apt-get update -y
-              sudo apt-get upgrade
               # Deal with Github CI limitation
               # https://github.com/actions/runner-images/issues/6399#issuecomment-1285011525
               sudo apt install -y libunwind-dev

--- a/.github/workflows/build-and-test_projects.yml
+++ b/.github/workflows/build-and-test_projects.yml
@@ -30,7 +30,6 @@ jobs:
           if [ "$RUNNER_OS" == "Linux" ]; then
               # Update & upgrade package lists
               sudo apt-get update -y
-              sudo apt-get upgrade
               # Deal with Github CI limitation
               # https://github.com/actions/runner-images/issues/6399#issuecomment-1285011525
               sudo apt install -y libunwind-dev


### PR DESCRIPTION
Summary: As we are running update and install libraries later, we don't need to run upgrade.

Differential Revision: D72653490


