### PR TITLE
Fix type annotation in PointsAndObservationsManager.py

### DIFF
--- a/tools/samples/python/mps_semidense_point_visibility/PointsAndObservationsManager.py
+++ b/tools/samples/python/mps_semidense_point_visibility/PointsAndObservationsManager.py
@@ -37,7 +37,7 @@ if sys.version_info < (3, 10):
 
 
 PointsDict = Dict[int, GlobalPointPosition]
-ObservationIndex = Dict[Tuple[int, str], Tuple[int, int]]
+ObservationIndex = Dict[Tuple[timedelta, str], Tuple[int, int]]
 PointsUVsList = List[Tuple[float, float]]
 PointsIndexList = List[int]
 PointsUVsAndIDs = Tuple[PointsUVsList, PointsIndexList]


### PR DESCRIPTION
The type annotation is wrong:
ObservationIndex = Dict[Tuple[int, str], Tuple[int, int]]

it should be:
ObservationIndex = Dict[Tuple[timedelta, str], Tuple[int, int]]