### PR TITLE
{BugFix} Display rec path on error

### DIFF
--- a/projectaria_tools/aria_mps_cli/cli_lib/multi_recording_request.py
+++ b/projectaria_tools/aria_mps_cli/cli_lib/multi_recording_request.py
@@ -436,7 +436,7 @@ class MultiRecordingModel:
                 )
                 await vhc_runner.run()
             if not rec.health_check_path.is_file():
-                logger.error("Failed to run VrsHealthCheck for {rec.path}")
+                logger.error(f"Failed to run VrsHealthCheck for {rec.path}")
                 self._error_codes[rec.path] = ErrorCode.HEALTH_CHECK_FAILURE
                 raise VrsHealthCheckError()
 


### PR DESCRIPTION
## PR Summary
This small PR evaluates and displays the `rec.path` in error message.