### PR TITLE
This json file should make the ATEK section display properly. 

### DIFF
--- a/website/docs/ATEK/_category_.json
+++ b/website/docs/ATEK/_category_.json
@@ -1,0 +1,4 @@
+{
+    "label": "ATEK",
+    "position": 55
+  }


### PR DESCRIPTION
Hi folks,

I hope you're doing well. It's really bothering me that the ATEK section doesn't display properly! This json file should do the trick. Adjust the position based on where you'd like it to go.

I ran into a babel issue and wasn't able to test it locally. I think it might be some internal Meta dependency, but it should work.

Best

Liz