### PR TITLE
{Feature} Templated CameraProjection BugFix

### DIFF
--- a/core/calibration/camera_projections/CameraProjection.cpp
+++ b/core/calibration/camera_projections/CameraProjection.cpp
@@ -19,7 +19,7 @@
 
 namespace projectaria::tools::calibration {
 template <typename Scalar>
-CameraProjection::ProjectionVariant getProjectionVariant(
+typename CameraProjectionTemplated<Scalar>::ProjectionVariant getProjectionVariant(
     const typename CameraProjectionTemplated<Scalar>::ModelType& type) {
   switch (type) {
     case CameraProjectionTemplated<Scalar>::ModelType::Linear:
@@ -44,8 +44,9 @@ CameraProjectionTemplated<Scalar>::CameraProjectionTemplated(
       projectionParams_(projectionParams),
       projectionVariant_(getProjectionVariant<Scalar>(type)) {}
 
-template <>
-CameraProjection::ModelType CameraProjection::modelName() const {
+template <typename Scalar>
+typename CameraProjectionTemplated<Scalar>::ModelType CameraProjectionTemplated<Scalar>::modelName()
+    const {
   return modelName_;
 }
 


### PR DESCRIPTION
Summary:
There were a couple of bugs in CameraProjection.cpp where we wanted to instantiate polymorphic template functions for CameraProjectionTemplated<Scalar>, but were accidently instantiating them only for CameraProjection (which is just an alias for CameraProjectionTemplated<double>)

This in practise meant that we can't use the modelName() function when were using the <float> instantiation

Differential Revision: D75812900


