### PR TITLE
{Build} CI - Windows Github Infra migration

### DIFF
--- a/.github/workflows/build-and-test-pixi.yml
+++ b/.github/workflows/build-and-test-pixi.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-13, macos-14, windows-2019] # macos-14 is macSilicon
+        os: [ubuntu-latest, macos-13, macos-14, windows-2022] # macos-14 is macSilicon
     steps:
       - name : Setup repo
         uses: actions/checkout@v4
@@ -43,7 +43,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-13, macos-14, windows-2019] # macos-14 is macSilicon
+        os: [ubuntu-latest, macos-13, macos-14, windows-2022] # macos-14 is macSilicon
     steps:
       - name : Setup repo
         uses: actions/checkout@v4


### PR DESCRIPTION
Summary: Update GitHub runner image "windows-2022" due to the removal of "windows-2019" following GitHub migration infra change https://github.com/actions/runner-images/issues/12045

Differential Revision: D77604363


