### PR TITLE
Fix deprecated this capture in arvr/projects/ariane/aria_research_kit/projectaria_tools_gen1_legacy/core/data_provider/VrsDataProviderFactory.cpp +1

### DIFF
--- a/core/data_provider/VrsDataProviderFactory.cpp
+++ b/core/data_provider/VrsDataProviderFactory.cpp
@@ -119,7 +119,8 @@ void VrsDataProviderFactory::addPlayers() {
     const SensorDataType sensorDataType = getSensorDataType(streamId.getTypeId());
 
     // Define a lambda that sets the StreamPlayer to the reader and log its streamId
-    auto setStreamAndLog = [=](const vrs::StreamId, vrs::RecordFormatStreamPlayer* player) -> void {
+    auto setStreamAndLog = [=, this](
+                               const vrs::StreamId, vrs::RecordFormatStreamPlayer* player) -> void {
       reader_->setStreamPlayer(streamId, player);
       XR_LOGI(
           "streamId {}/{} activated",


### PR DESCRIPTION
Summary:
In the future LLVM will require that lambdas capture `this` explicitly. `-Wdeprecated-this-capture` checks for and enforces this now.

This diff adds an explicit `this` capture to a lambda to fix an issue that presents similarly to this:
```
   -> fbcode/path/to/my_file.cpp:66:47: error: implicit capture of 'this' with a capture default of '=' is deprecated [-Werror,-
Wdeprecated-this-capture]
   ->           detail::createIOWorkerProvider(evb, requestsRegistry_);
   ->                                               ^
   -> fbcode/path/to/my_file.cpp:61:30: note: add an explicit capture of 'this' to capture '*this' by reference
   ->   evb->runInEventBaseThread([=, self_weak = std::move(self_weak)]() {
   ->                              ^
   ->                               , this
```

Differential Revision: D82976785


