### PR TITLE
docs: fix sample.vrs link in dataprovider_quickstart_tutorial notebook

### DIFF
--- a/examples/Gen2/python_notebooks/dataprovider_quickstart_tutorial.ipynb
+++ b/examples/Gen2/python_notebooks/dataprovider_quickstart_tutorial.ipynb
@@ -28,7 +28,7 @@
                 "    print(\"Running from Google Colab, installing projectaria_tools and getting sample data\")\n",
                 "    !pip install projectaria-tools\n",
                 "    # TODO: Update the data path here.\n",
-                "    !curl -O -J -L \"https://github.com/facebookresearch/projectaria_tools/raw/main/data/mps_sample/sample.vrs\"\n",
+                "    !curl -O -J -L  \"https://github.com/facebookresearch/projectaria_tools/raw/main/data/gen1/mps_sample/sample.vrs\"\n",
                 "    vrsfile = \"sample.vrs\"\n",
                 "else:\n",
                 "    print(\"Using a pre-existing projectaria_tool github repository\")\n",


### PR DESCRIPTION
### Summary
Fixes the incorrect `sample.vrs` download URL in the [`dataprovider_quickstart_tutorial`](https://github.com/facebookresearch/projectaria_tools/blob/main/examples/Gen2/python_notebooks/dataprovider_quickstart_tutorial.ipynb) notebook.

### What changed
Updated the first cell to use the correct `sample.vrs` path.

### Why
The previous link returned 404, preventing the data provider from initializing. 

### How tested
- Ran the corrected cell in Colab and confirmed `sample.vrs` downloads.
- Verified the rest of the notebook executes successfully.
