### PR TITLE
{Feature} Properly fix LLVM and MSVC requirement on capturing this in lambda.

### DIFF
--- a/core/data_provider/VrsDataProviderFactory.cpp
+++ b/core/data_provider/VrsDataProviderFactory.cpp
@@ -178,7 +178,7 @@ void VrsDataProviderFactory::addPlayers() {
         getSensorDataType(streamId.getTypeId(), reader_->getFlavor(streamId));
 
     // Define a lambda that sets the StreamPlayer to the reader and log its streamId
-    auto setStreamAndLog = [=, this](
+    auto setStreamAndLog = [this, streamId](
                                const vrs::StreamId, vrs::RecordFormatStreamPlayer* player) -> void {
       reader_->setStreamPlayer(streamId, player);
       XR_LOGI(


### PR DESCRIPTION
Summary: This is for satisfying both the condition in D82976785, and address the failure in https://github.com/facebookresearch/projectaria_tools/actions/runs/18177647617/job/51747469890. Basically, you just can't do `[=, this]` under MSVC 2017.

Reviewed By: SeaOtocinclus

Differential Revision: D83720296


