### PR TITLE
save/load camera config to avoid read-adapting

### DIFF
--- a/core/calibration/loader/DeviceCalibrationJson.cpp
+++ b/core/calibration/loader/DeviceCalibrationJson.cpp
@@ -82,7 +82,7 @@ std::optional<DeviceCalibration> deviceCalibrationFromJson(const std::string& ca
     deviceSubtype = json["DeviceClassInfo"]["BuildVersion"];
   }
 
-  // Create a Camera Config builder to parse in camera config information
+  // Create a Camera Config builder to parse in camera default config information
   CameraConfigBuilder cameraConfigBuilder(deviceVersion);
 
   std::map<std::string, CameraCalibration> cameraCalibs;
@@ -204,6 +204,15 @@ nlohmann::json cameraCalibrationToJson(const CameraCalibration& camCalib) {
   // Time offset if non-zero
   if (camCalib.getTimeOffsetSecDeviceCamera() != 0.0) {
     camJson["TimeOffsetSec_Device_Camera"] = camCalib.getTimeOffsetSecDeviceCamera();
+  }
+
+  // Store config, so we can correctly load an already configured camera without re-applying
+  auto& jsonConfig = camJson["ConfigData"];
+  jsonConfig["ImageWidth"] = camCalib.getImageSize().x();
+  jsonConfig["ImageHeight"] = camCalib.getImageSize().y();
+  jsonConfig["MaxSolidAngle"] = camCalib.getMaxSolidAngle();
+  if(camCalib.getValidRadius().has_value()) {
+    jsonConfig["ValidRadius"] = *camCalib.getValidRadius();
   }
 
   return camJson;

--- a/core/calibration/loader/SensorCalibrationJson.cpp
+++ b/core/calibration/loader/SensorCalibrationJson.cpp
@@ -53,11 +53,27 @@ CameraCalibration parseCameraCalibrationFromJson(
       ? static_cast<double>(json["TimeOffsetSec_Device_Camera"])
       : 0.0;
 
-  // Obtain camera config from builder
-  const auto maybeConfig = configBuilder.getCameraConfigData(label);
-  if (!maybeConfig.has_value()) {
-    throw std::runtime_error(
-        fmt::format("No config found for camera {} from Config builder", label));
+  // load saved config, if available - if not, then defaults will be loaded
+  std::optional<CameraConfigData> maybeConfig;
+  if(json.contains("ConfigData")) {
+    auto jsonConfig = json["ConfigData"];
+    maybeConfig = CameraConfigData {
+      .imageWidth = jsonConfig["ImageWidth"],
+      .imageHeight = jsonConfig["ImageHeight"],
+      .maxSolidAngle = jsonConfig["MaxSolidAngle"],
+    };
+    if(jsonConfig.contains("ValidRadius")) {
+      maybeConfig->maybeValidRadius = static_cast<double>(jsonConfig["ValidRadius"]);
+    }
+  }
+
+  // Obtain default camera config from builder
+  if(!maybeConfig.has_value()) {
+    maybeConfig = configBuilder.getCameraConfigData(label);
+    if (!maybeConfig.has_value()) {
+      throw std::runtime_error(
+          fmt::format("No config found for camera {} from Config builder", label));
+    }
   }
 
   CameraCalibration camCalib(


### PR DESCRIPTION
When loading from VRS, the factory calibration is adapted to the current resolution *ASSUMING* that those values are for a default resolution (2880 x 2880 for RGB camera).
Therefore the process of saving and reloading from JSON is currently broken, as the scaling would be applied TWICE.
The current diff makes sure the config data are saved and used if available. if not present, the default is assumed (like when loading from VRS) and loaded as usual.
This is required to make VI-BA work.
