### PR TITLE
{Build} Fixing Ocean library hash

### DIFF
--- a/cmake/FindOcean.cmake
+++ b/cmake/FindOcean.cmake
@@ -30,7 +30,7 @@ include(FetchContent)
 FetchContent_Declare(
   ocean
   GIT_REPOSITORY https://github.com/facebookresearch/ocean.git
-  GIT_TAG        origin/main
+  GIT_TAG        5fca1d27a9f37e868738b6db09a6b1e00723d80f # master branch, 2025.11.07
 )
 set(OCEAN_BUILD_MINIMAL ON)
 set(OCEAN_BUILD_TEST    OFF)


### PR DESCRIPTION
Summary: This diff uses a fixed ocean library hash, instead of using master.

Reviewed By: chpeng-fb

Differential Revision: D86558903


