### PR TITLE
{Feature} Calib jacobians (#293)

### DIFF
--- a/core/calibration/CameraCalibration.cpp
+++ b/core/calibration/CameraCalibration.cpp
@@ -30,7 +30,7 @@ CameraCalibration::CameraCalibration(
     const double maxSolidAngle,
     const std::string& serialNumber,
     const double timeOffsetSecDeviceCamera,
-    const std::optional<double> maybeReadOutTimeSec)
+    const std::optional<double>& maybeReadOutTimeSec)
     : label_(label),
       projectionModel_(projectionModelType, projectionParams),
       T_Device_Camera_(T_Device_Camera),
@@ -70,7 +70,15 @@ double CameraCalibration::getTimeOffsetSecDeviceCamera() const {
   return timeOffsetSecDeviceCamera_;
 }
 
+double& CameraCalibration::getTimeOffsetSecDeviceCameraMut() {
+  return timeOffsetSecDeviceCamera_;
+}
+
 std::optional<double> CameraCalibration::getReadOutTimeSec() const {
+  return maybeReadOutTimeSec_;
+}
+
+std::optional<double>& CameraCalibration::getReadOutTimeSecMut() {
   return maybeReadOutTimeSec_;
 }
 
@@ -110,8 +118,24 @@ CameraProjection::ModelType CameraCalibration::modelName() const {
   return projectionModel_.modelName();
 }
 
-Eigen::VectorXd CameraCalibration::projectionParams() const {
+const Eigen::VectorXd& CameraCalibration::projectionParams() const {
   return projectionModel_.projectionParams();
+}
+
+Eigen::VectorXd& CameraCalibration::projectionParamsMut() {
+  return projectionModel_.projectionParamsMut();
+}
+
+int CameraCalibration::numParameters() const {
+  return projectionModel_.numParameters();
+}
+
+int CameraCalibration::numProjectionParameters() const {
+  return projectionModel_.numProjectionParameters();
+}
+
+int CameraCalibration::numDistortionParameters() const {
+  return projectionModel_.numDistortionParameters();
 }
 
 Eigen::Vector2d CameraCalibration::getPrincipalPoint() const {
@@ -122,15 +146,21 @@ Eigen::Vector2d CameraCalibration::getFocalLengths() const {
   return projectionModel_.getFocalLengths();
 }
 
-Eigen::Vector2d CameraCalibration::projectNoChecks(const Eigen::Vector3d& pointInCamera) const {
-  return projectionModel_.project(pointInCamera);
+Eigen::Vector2d CameraCalibration::projectNoChecks(
+    const Eigen::Vector3d& pointInCamera,
+    Eigen::Ref<Eigen::Matrix<double, 2, 3>> jacobianWrtPoint,
+    Eigen::Ref<Eigen::Matrix<double, 2, Eigen::Dynamic>> jacobianWrtParams) const {
+  return projectionModel_.project(pointInCamera, jacobianWrtPoint, jacobianWrtParams);
 }
 
 std::optional<Eigen::Vector2d> CameraCalibration::project(
-    const Eigen::Vector3d& pointInCamera) const {
+    const Eigen::Vector3d& pointInCamera,
+    Eigen::Ref<Eigen::Matrix<double, 2, 3>> jacobianWrtPoint,
+    Eigen::Ref<Eigen::Matrix<double, 2, Eigen::Dynamic>> jacobianWrtParams) const {
   // check point is in front of camera
   if (checkPointInVisibleCone(pointInCamera, maxSolidAngle_)) {
-    const Eigen::Vector2d cameraPixel = projectNoChecks(pointInCamera);
+    const Eigen::Vector2d cameraPixel =
+        projectNoChecks(pointInCamera, jacobianWrtPoint, jacobianWrtParams);
     if (isVisible(cameraPixel)) {
       return cameraPixel;
     }

--- a/core/calibration/camera_projections/CMakeLists.txt
+++ b/core/calibration/camera_projections/CMakeLists.txt
@@ -27,5 +27,6 @@ target_link_libraries(camera_models INTERFACE common)
 target_include_directories(camera_models INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>)
 
 add_library(camera_projection CameraProjection.cpp CameraProjection.h CameraProjectionFormat.h)
+target_link_libraries(camera_projection INTERFACE calibration_nullref)
 target_include_directories(camera_projection PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>)
 target_link_libraries(camera_projection PUBLIC camera_models format Eigen3::Eigen Sophus::Sophus)

--- a/core/calibration/camera_projections/CameraProjection.cpp
+++ b/core/calibration/camera_projections/CameraProjection.cpp
@@ -39,7 +39,7 @@ typename CameraProjectionTemplated<Scalar>::ProjectionVariant getProjectionVaria
 template <typename Scalar>
 CameraProjectionTemplated<Scalar>::CameraProjectionTemplated(
     const ModelType& type,
-    const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>& projectionParams)
+    const Eigen::Vector<Scalar, Eigen::Dynamic>& projectionParams)
     : modelName_(type),
       projectionParams_(projectionParams),
       projectionVariant_(getProjectionVariant<Scalar>(type)) {}
@@ -51,15 +51,50 @@ typename CameraProjectionTemplated<Scalar>::ModelType CameraProjectionTemplated<
 }
 
 template <typename Scalar>
-Eigen::Matrix<Scalar, Eigen::Dynamic, 1> CameraProjectionTemplated<Scalar>::projectionParams()
+const Eigen::Vector<Scalar, Eigen::Dynamic>& CameraProjectionTemplated<Scalar>::projectionParams()
     const {
   return projectionParams_;
 }
 
 template <typename Scalar>
-Eigen::Matrix<Scalar, 2, 1> CameraProjectionTemplated<Scalar>::getFocalLengths() const {
+Eigen::Vector<Scalar, Eigen::Dynamic>& CameraProjectionTemplated<Scalar>::projectionParamsMut() {
+  return projectionParams_;
+}
+
+template <typename Scalar>
+int CameraProjectionTemplated<Scalar>::numParameters() const {
   return std::visit(
-      [this](auto&& projection) -> Eigen::Matrix<Scalar, 2, 1> {
+      [](auto&& projection) -> int {
+        using T = std::decay_t<decltype(projection)>;
+        return T::kNumParams;
+      },
+      projectionVariant_);
+}
+
+template <typename Scalar>
+int CameraProjectionTemplated<Scalar>::numProjectionParameters() const {
+  return std::visit(
+      [](auto&& projection) -> int {
+        using T = std::decay_t<decltype(projection)>;
+        return T::kNumParams - T::kNumDistortionParams;
+      },
+      projectionVariant_);
+}
+
+template <typename Scalar>
+int CameraProjectionTemplated<Scalar>::numDistortionParameters() const {
+  return std::visit(
+      [](auto&& projection) -> int {
+        using T = std::decay_t<decltype(projection)>;
+        return T::kNumDistortionParams;
+      },
+      projectionVariant_);
+}
+
+template <typename Scalar>
+Eigen::Vector<Scalar, 2> CameraProjectionTemplated<Scalar>::getFocalLengths() const {
+  return std::visit(
+      [this](auto&& projection) -> Eigen::Vector<Scalar, 2> {
         using T = std::decay_t<decltype(projection)>;
         int focalXIdx = T::kFocalXIdx;
         int focalYIdx = T::kFocalYIdx;
@@ -69,9 +104,9 @@ Eigen::Matrix<Scalar, 2, 1> CameraProjectionTemplated<Scalar>::getFocalLengths()
 }
 
 template <typename Scalar>
-Eigen::Matrix<Scalar, 2, 1> CameraProjectionTemplated<Scalar>::getPrincipalPoint() const {
+Eigen::Vector<Scalar, 2> CameraProjectionTemplated<Scalar>::getPrincipalPoint() const {
   return std::visit(
-      [this](auto&& projection) -> Eigen::Matrix<Scalar, 2, 1> {
+      [this](auto&& projection) -> Eigen::Vector<Scalar, 2> {
         using T = std::decay_t<decltype(projection)>;
         int principalPointColIdx = T::kPrincipalPointColIdx;
         int principalPointRowIdx = T::kPrincipalPointRowIdx;
@@ -81,20 +116,25 @@ Eigen::Matrix<Scalar, 2, 1> CameraProjectionTemplated<Scalar>::getPrincipalPoint
 }
 
 template <typename Scalar>
-Eigen::Matrix<Scalar, 2, 1> CameraProjectionTemplated<Scalar>::project(
-    const Eigen::Matrix<Scalar, 3, 1>& pointInCamera,
-    Eigen::Matrix<Scalar, 2, 3>* jacobianWrtPoint) const {
+Eigen::Vector<Scalar, 2> CameraProjectionTemplated<Scalar>::project(
+    const Eigen::Vector<Scalar, 3>& pointInCamera,
+    Eigen::Ref<Eigen::Matrix<Scalar, 2, 3>> jacobianWrtPoint,
+    Eigen::Ref<Eigen::Matrix<Scalar, 2, Eigen::Dynamic>> jacobianWrtParams) const {
   return std::visit(
       [&](auto&& projection) {
         using T = std::decay_t<decltype(projection)>;
-        return T::project(pointInCamera, projectionParams_, jacobianWrtPoint);
+        return T::project(
+            pointInCamera,
+            projectionParams_,
+            isNull(jacobianWrtPoint) ? nullptr : &jacobianWrtPoint,
+            isNull(jacobianWrtParams) ? nullptr : &jacobianWrtParams);
       },
       projectionVariant_);
 }
 
 template <typename Scalar>
-Eigen::Matrix<Scalar, 3, 1> CameraProjectionTemplated<Scalar>::unproject(
-    const Eigen::Matrix<Scalar, 2, 1>& cameraPixel) const {
+Eigen::Vector<Scalar, 3> CameraProjectionTemplated<Scalar>::unproject(
+    const Eigen::Vector<Scalar, 2>& cameraPixel) const {
   return std::visit(
       [&](auto&& projection) {
         using T = std::decay_t<decltype(projection)>;
@@ -127,7 +167,7 @@ template <typename Scalar>
 template <typename OtherScalar>
 [[nodiscard]] CameraProjectionTemplated<OtherScalar> CameraProjectionTemplated<Scalar>::cast()
     const {
-  Eigen::Matrix<OtherScalar, Eigen::Dynamic, 1> castedParams =
+  Eigen::Vector<OtherScalar, Eigen::Dynamic> castedParams =
       projectionParams_.template cast<OtherScalar>();
   auto castedModelName =
       static_cast<typename CameraProjectionTemplated<OtherScalar>::ModelType>(modelName_);

--- a/core/calibration/camera_projections/CameraProjection.h
+++ b/core/calibration/camera_projections/CameraProjection.h
@@ -25,6 +25,7 @@
 #include <calibration/camera_projections/Linear.h>
 #include <calibration/camera_projections/Spherical.h>
 
+#include <calibration/utility/NullRef.h>
 #include <Eigen/Core>
 
 namespace projectaria::tools::calibration {
@@ -54,16 +55,40 @@ struct CameraProjectionTemplated {
   CameraProjectionTemplated() = default;
 
   /**
+   * @brief Default copy constructor.
+   */
+  CameraProjectionTemplated(const CameraProjectionTemplated&) = default;
+
+  /**
+   * @brief Default move constructor.
+   */
+  CameraProjectionTemplated(CameraProjectionTemplated&&) = default;
+
+  /**
+   * @brief Default copy assignment.
+   */
+  CameraProjectionTemplated& operator=(const CameraProjectionTemplated&) = default;
+
+  /**
+   * @brief Default move assignment.
+   */
+  CameraProjectionTemplated& operator=(CameraProjectionTemplated&&) = default;
+
+  /**
    * @brief Constructor with a list of parameters for CameraProjectionTemplated.
    * @param type The type of projection model, e.g. ModelType::Linear.
    * @param projectionParams The projection parameters.
    */
   CameraProjectionTemplated(
       const ModelType& type,
-      const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>& projectionParams);
+      const Eigen::Vector<Scalar, Eigen::Dynamic>& projectionParams);
 
   ModelType modelName() const;
-  Eigen::Matrix<Scalar, Eigen::Dynamic, 1> projectionParams() const;
+  const Eigen::Vector<Scalar, Eigen::Dynamic>& projectionParams() const;
+  Eigen::Vector<Scalar, Eigen::Dynamic>& projectionParamsMut();
+  int numParameters() const; // return number of parameters
+  int numProjectionParameters() const; // return number of projection parameters
+  int numDistortionParameters() const; // return number of distortion parameters
 
   /**
    * @brief projects a 3d world point in the camera space to a 2d pixel in the image space. No
@@ -72,27 +97,30 @@ struct CameraProjectionTemplated {
    * @param pointInCamera The 3D point in camera space to be projected.
    * @param jacobianWrtPoint Optional, if not null, will store the Jacobian of the projection
    * with respect to the point in camera space.
+   * @param jacobianWrtParams Optional, if not null, will store the Jacobian of the projection
+   * with respect to the projection parameters.
    *
    * @return The 2D pixel coordinates of the projected point in the image space.
    */
-  Eigen::Matrix<Scalar, 2, 1> project(
-      const Eigen::Matrix<Scalar, 3, 1>& pointInCamera,
-      Eigen::Matrix<Scalar, 2, 3>* jacobianWrtPoint = nullptr) const;
+  Eigen::Vector<Scalar, 2> project(
+      const Eigen::Vector<Scalar, 3>& pointInCamera,
+      Eigen::Ref<Eigen::Matrix<Scalar, 2, 3>> jacobianWrtPoint = NullRef(),
+      Eigen::Ref<Eigen::Matrix<Scalar, 2, Eigen::Dynamic>> jacobianWrtParams = NullRef()) const;
 
   /**
    * @brief unprojects a 2d pixel in the image space to a 3d world point in homogenous coordinate.
    * No checks performed in this process.
    */
-  Eigen::Matrix<Scalar, 3, 1> unproject(const Eigen::Matrix<Scalar, 2, 1>& cameraPixel) const;
+  Eigen::Vector<Scalar, 3> unproject(const Eigen::Vector<Scalar, 2>& cameraPixel) const;
 
   /**
    * @brief returns principal point location as {cx, cy}
    */
-  Eigen::Matrix<Scalar, 2, 1> getPrincipalPoint() const;
+  Eigen::Vector<Scalar, 2> getPrincipalPoint() const;
   /**
    * @brief returns focal lengths as {fx, fy}
    */
-  Eigen::Matrix<Scalar, 2, 1> getFocalLengths() const;
+  Eigen::Vector<Scalar, 2> getFocalLengths() const;
 
   /**
    * @brief scales the projection parameters as the image scales without the offset changing
@@ -120,7 +148,7 @@ struct CameraProjectionTemplated {
 
  private:
   ModelType modelName_;
-  Eigen::Matrix<Scalar, Eigen::Dynamic, 1> projectionParams_;
+  Eigen::Vector<Scalar, Eigen::Dynamic> projectionParams_;
   ProjectionVariant projectionVariant_;
 };
 using CameraProjection = CameraProjectionTemplated<double>;

--- a/core/calibration/camera_projections/FisheyeRadTanThinPrism.h
+++ b/core/calibration/camera_projections/FisheyeRadTanThinPrism.h
@@ -71,11 +71,16 @@ class FisheyeRadTanThinPrism {
   static constexpr bool kIsFisheye = true;
   static constexpr bool kHasAnalyticalProjection = true;
 
-  template <class D, class DP, class DJ = Eigen::Matrix<typename D::Scalar, 2, 3>>
+  template <
+      class D,
+      class DP,
+      class DJ1 = Eigen::Matrix<typename D::Scalar, 2, 3>,
+      class DJ2 = Eigen::Matrix<typename D::Scalar, 2, kNumParams>>
   static Eigen::Matrix<typename D::Scalar, 2, 1> project(
       const Eigen::MatrixBase<D>& pointOptical,
       const Eigen::MatrixBase<DP>& params,
-      Eigen::MatrixBase<DJ>* d_point = nullptr) {
+      Eigen::MatrixBase<DJ1>* d_point = nullptr,
+      Eigen::MatrixBase<DJ2>* d_param = nullptr) {
     using T = typename D::Scalar;
 
     validateProjectInput<D, DP, kNumParams>();
@@ -138,41 +143,90 @@ class FisheyeRadTanThinPrism {
     }
 
     // Maybe compute point jacobian
-    if (d_point) {
+    if (d_param || d_point) {
       Eigen::Matrix<T, 2, 2> duvDistorted_dxryr;
       compute_duvDistorted_dxryr(xr_yr, xr_yr_squaredNorm, params, duvDistorted_dxryr);
 
       // compute jacobian wrt point
-      Eigen::Matrix<T, 2, 2> duvDistorted_dab;
-      if (r == static_cast<T>(0.0)) {
-        duvDistorted_dab.setIdentity();
-      } else {
-        T dthD_dth = static_cast<T>(1.0);
-        T theta2i = thetaSq;
-        for (size_t i = 0; i < numK; ++i) {
-          dthD_dth += T(2 * i + 3) * params[startK + i] * theta2i;
-          theta2i *= thetaSq;
+      if (d_point) {
+        Eigen::Matrix<T, 2, 2> duvDistorted_dab;
+        if (r == static_cast<T>(0.0)) {
+          duvDistorted_dab.setIdentity();
+        } else {
+          T dthD_dth = static_cast<T>(1.0);
+          T theta2i = thetaSq;
+          for (size_t i = 0; i < numK; ++i) {
+            dthD_dth += T(2 * i + 3) * params[startK + i] * theta2i;
+            theta2i *= thetaSq;
+          }
+
+          const T w1 = dthD_dth / (r_sq + r_sq * r_sq);
+          const T w2 = th_radial * th_divr / r_sq;
+          const T ab10 = ab[0] * ab[1];
+          Eigen::Matrix<T, 2, 2> temp1;
+          temp1(0, 0) = w1 * ab_squared[0] + w2 * ab_squared[1];
+          temp1(0, 1) = (w1 - w2) * ab10;
+          temp1(1, 0) = temp1(0, 1);
+          temp1(1, 1) = w1 * ab_squared[1] + w2 * ab_squared[0];
+          duvDistorted_dab.noalias() = duvDistorted_dxryr * temp1;
         }
 
-        const T w1 = dthD_dth / (r_sq + r_sq * r_sq);
-        const T w2 = th_radial * th_divr / r_sq;
-        const T ab10 = ab[0] * ab[1];
-        Eigen::Matrix<T, 2, 2> temp1;
-        temp1(0, 0) = w1 * ab_squared[0] + w2 * ab_squared[1];
-        temp1(0, 1) = (w1 - w2) * ab10;
-        temp1(1, 0) = temp1(0, 1);
-        temp1(1, 1) = w1 * ab_squared[1] + w2 * ab_squared[0];
-        duvDistorted_dab.noalias() = duvDistorted_dxryr * temp1;
+        // compute the derivative of the projection wrt the point:
+        if (useSingleFocalLength) {
+          d_point->template leftCols<2>() = params[0] * inv_z * duvDistorted_dab;
+        } else {
+          d_point->template leftCols<2>() =
+              params.template head<2>().asDiagonal() * duvDistorted_dab * inv_z;
+        }
+        d_point->template rightCols<1>().noalias() = -d_point->template leftCols<2>() * ab;
       }
 
-      // compute the derivative of the projection wrt the point:
-      if (useSingleFocalLength) {
-        d_point->template leftCols<2>() = params[0] * inv_z * duvDistorted_dab;
-      } else {
-        d_point->template leftCols<2>() =
-            params.template head<2>().asDiagonal() * duvDistorted_dab * inv_z;
+      if (d_param) {
+        if constexpr (useSingleFocalLength) {
+          d_param->template leftCols<1>() = uvDistorted;
+        } else {
+          d_param->template leftCols<2>() = uvDistorted.asDiagonal();
+        }
+
+        d_param->template middleCols<2>(kPrincipalPointColIdx).setIdentity();
+
+        if (numK > 0) {
+          Eigen::Matrix<T, 2, 1> temp;
+          if constexpr (useSingleFocalLength) {
+            temp = (params[kFocalXIdx] * th_divr) * duvDistorted_dxryr * ab;
+          } else {
+            temp = params.template head<2>().cwiseProduct(th_divr * (duvDistorted_dxryr * ab));
+          }
+          T theta2i = thetaSq;
+          for (size_t i = 0; i < numK; ++i) {
+            d_param->col(startK + i) = theta2i * temp;
+            theta2i *= thetaSq;
+          }
+        }
+
+        // tangential terms
+        if (useTangential) {
+          if constexpr (useSingleFocalLength) {
+            d_param->template middleCols<2>(startP).noalias() =
+                T(2) * params[kFocalXIdx] * xr_yr * xr_yr.transpose();
+            const T temp3 = params[kFocalXIdx] * xr_yr_squaredNorm;
+            (*d_param)(0, startP) += temp3;
+            (*d_param)(1, startP + 1) += temp3;
+          } else {
+            d_param->template middleCols<2>(startP).noalias() =
+                T(2) * xr_yr.cwiseProduct(params.template head<2>()) * xr_yr.transpose();
+            (*d_param)(0, startP) += params[kFocalXIdx] * xr_yr_squaredNorm;
+            (*d_param)(1, startP + 1) += params[kFocalYIdx] * xr_yr_squaredNorm;
+          }
+        }
+
+        if (useThinPrism) {
+          d_param->template block<1, 2>(0, startS) = params[kFocalXIdx] * radialPowers2And4;
+          d_param->template block<1, 2>(1, startS).setZero();
+          d_param->template block<1, 2>(0, startS + 2).setZero();
+          d_param->template block<1, 2>(1, startS + 2) = params[kFocalYIdx] * radialPowers2And4;
+        }
       }
-      d_point->template rightCols<1>().noalias() = -d_point->template leftCols<2>() * ab;
     }
 
     // compute the return value

--- a/core/calibration/camera_projections/Spherical.h
+++ b/core/calibration/camera_projections/Spherical.h
@@ -49,12 +49,17 @@ class SphericalProjection {
   //
   // Return 2-point in the image plane.
   //
-  template <class D, class DP, class DJ = Eigen::Matrix<typename D::Scalar, 2, 3>>
+  template <
+      class D,
+      class DP,
+      class DJ1 = Eigen::Matrix<typename D::Scalar, 2, 3>,
+      class DJ2 = Eigen::Matrix<typename D::Scalar, 2, kNumParams>>
   static Eigen::Matrix<typename D::Scalar, 2, 1> project(
       const Eigen::MatrixBase<D>& pointOptical,
       const Eigen::MatrixBase<DP>& params,
-      Eigen::MatrixBase<DJ>* d_point = nullptr) {
-    if (d_point != nullptr) {
+      Eigen::MatrixBase<DJ1>* d_point = nullptr,
+      Eigen::MatrixBase<DJ2>* d_params = nullptr) {
+    if (d_point != nullptr || d_params != nullptr) {
       throw std::runtime_error("Jacobians not implemented in Spherical projection model");
     }
 

--- a/core/calibration/utility/CMakeLists.txt
+++ b/core/calibration/utility/CMakeLists.txt
@@ -15,3 +15,8 @@
 add_library(calibration_distort Distort.cpp Distort.h)
 target_include_directories(calibration_distort PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../..)
 target_link_libraries(calibration_distort PUBLIC device_calibration image_distort)
+
+add_library(calibration_nullref INTERFACE)
+target_sources(calibration_nullref INTERFACE NullRef.h)
+target_link_libraries(calibration_nullref INTERFACE Eigen3::Eigen)
+target_include_directories(calibration_nullref INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>)

--- a/core/calibration/utility/NullRef.h
+++ b/core/calibration/utility/NullRef.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <Eigen/Core>
+
+namespace projectaria::tools::calibration {
+
+/// Get an Eigen reference pointing to a nullptr.
+template <
+    typename Scalar,
+    int Rows = Eigen::Dynamic,
+    int Columns = Eigen::Dynamic,
+    int StorageOrder = Eigen::ColMajor>
+constexpr Eigen::Ref<Eigen::Matrix<Scalar, Rows, Columns, StorageOrder>> nullRef(
+    const int rows = Rows != Eigen::Dynamic ? Rows : 0,
+    const int columns = Columns != Eigen::Dynamic ? Columns : 0) {
+  return Eigen::Map<Eigen::Matrix<Scalar, Rows, Columns, StorageOrder>>(nullptr, rows, columns);
+}
+
+/// Test if an Eigen Reference is pointing to a nullptr.
+template <typename Base>
+constexpr bool isNull(const Eigen::Ref<Base>& ref) {
+  return ref.data() == nullptr;
+}
+
+/**
+ * A helper struct that allows direct assignments of NullRefs as function default
+ * arguments.
+ */
+struct NullRef {
+  /// The default constructor for general usecases.
+  NullRef() = default;
+
+  /// There might be edge cases where a dynamic sized NullRef is required. This
+  /// provides the option, while it should generally not be used.
+  NullRef(const int numRows, const int numCols) : numRows_(numRows), numCols_(numCols) {}
+
+  /// Fixed size matrices:
+  template <typename Scalar, int R, int C, int O, int MR, int MC>
+  operator Eigen::Ref<Eigen::Matrix<Scalar, R, C, O, MR, MC>>() {
+    return nullRef<Scalar, R, C, O>();
+  }
+  template <typename Scalar, int R, int C, int O, int MR, int MC>
+  operator Eigen::Ref<const Eigen::Matrix<Scalar, R, C, O, MR, MC>>() {
+    return nullRef<Scalar, R, C, O>();
+  }
+
+  /// Dynamic Matrices:
+  template <typename Scalar, int O, int MR, int MC>
+  operator Eigen::Ref<Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic, O, MR, MC>>() {
+    return nullRef<Scalar>(numRows_, numCols_);
+  }
+  template <typename Scalar, int O, int MR, int MC>
+  operator Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic, O, MR, MC>>() {
+    return nullRef<Scalar>(numRows_, numCols_);
+  }
+
+ private:
+  const int numRows_ = 0;
+  const int numCols_ = 0;
+};
+
+} // namespace projectaria::tools::calibration


### PR DESCRIPTION
Summary:
Add Jacobians wrt the calibration parameters.
This is required to make VI-BA work.

This diff also changes some return types to const references, as it is better practice to avoid creating temporary objects with dynamic allocation, and allows Mut fields so that the CameraCalibration type can be used in optimization.


Differential Revision: D85353427

Pulled By: maurimo


