### PR TITLE
{BugFix} Declaring py_object type for py_pickle function.

### DIFF
--- a/core/python/DeviceCalibrationPyBind.h
+++ b/core/python/DeviceCalibrationPyBind.h
@@ -666,7 +666,7 @@ inline void declareSensorCalibration(py::module& m) {
           "get the type of this sensor calibration as an enum.")
       .def(
           py::pickle(
-              [](const SensorCalibration& calib) {
+              [](const SensorCalibration& calib) -> py::tuple {
                 switch (calib.sensorCalibrationType()) {
                   case SensorCalibrationType::CameraCalibration:
                     return py::make_tuple(


### PR DESCRIPTION
Differential Revision: D87278592


