### PR TITLE
{Build} GitHub CI - remove macos-13 (#313)

### DIFF
--- a/.github/workflows/build-and-test-pixi.yml
+++ b/.github/workflows/build-and-test-pixi.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, macos-14] # macos-14 is macSilicon
+        os: [ubuntu-latest, macos-14] # macos-14 is macSilicon
     steps:
       - name : Setup repo
         uses: actions/checkout@v4
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, macos-14] # macos-14 is macSilicon
+        os: [ubuntu-latest, macos-14] # macos-14 is macSilicon
     steps:
       - name : Setup repo
         uses: actions/checkout@v4

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04,  macos-13, macos-14] # macos-14 is macSilicon
+        os: [ubuntu-22.04,  macos-14] # macos-14 is macSilicon
     steps:
       - name : Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build-and-test_projects.yml
+++ b/.github/workflows/build-and-test_projects.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-13, macos-14]  # macos-14 is macSilicon
+        os: [ubuntu-22.04, macos-14]  # macos-14 is macSilicon
         project: [
           PROJECTARIA_TOOLS_BUILD_PROJECTS_ADT,
           PROJECTARIA_TOOLS_BUILD_TOOLS]

--- a/.github/workflows/test-for-build-wheels.yml
+++ b/.github/workflows/test-for-build-wheels.yml
@@ -69,7 +69,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, macos-14, ubuntu-22.04] # macos-14 is macSilicon
+        os: [macos-14, ubuntu-22.04] # macos-14 is macSilicon
         python-version: ["3.10", "3.11", "3.12"]
         # Default consider only Python >=3.10 since actions/setup-python supports only python<3.10 and mac-silicon
         # Other Python versions are added below as matrix entries
@@ -80,17 +80,11 @@ jobs:
             cibw_build: "cp311-*"
           - python-version: "3.12"
             cibw_build: "cp312-*"
-          # Add matrix entries: Python ["3.8", "3.9"] to [macos-13, ubuntu-latest]
+          # Add matrix entries: Python ["3.8", "3.9"] to [ubuntu-latest]
           - os: ubuntu-22.04
             python-version: "3.8"
             cibw_build: "cp38-*"
           - os: ubuntu-22.04
-            python-version: "3.9"
-            cibw_build: "cp39-*"
-          - os: macos-13
-            python-version: "3.8"
-            cibw_build: "cp38-*"
-          - os: macos-13
             python-version: "3.9"
             cibw_build: "cp39-*"
 
@@ -113,7 +107,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install cibuildwheel==2.17.0
       - name: Install ffmpeg dependency lib
-        if: ${{ (matrix.os == 'macos-14') || (matrix.os == 'macos-13') || (matrix.os == 'ubuntu-22.04') }}
+        if: ${{ (matrix.os == 'macos-14') || (matrix.os == 'ubuntu-22.04') }}
         shell: bash
         run: |
           ./build_third_party_libs/build_ffmpeg_linuxunix.sh
@@ -128,7 +122,7 @@ jobs:
           CIBW_SKIP: "*-manylinux_i686 *-musllinux_* *x86_64*"
           CIBW_ARCHS: "arm64"
       - name: Build wheels for CPython
-        if: ${{ (matrix.os == 'macos-13') || (matrix.os == 'ubuntu-22.04') }}
+        if: ${{ (matrix.os == 'ubuntu-22.04') }}
         shell: bash
         run: |
           CMAKE_BUILD_PARALLEL_LEVEL=4 python -m cibuildwheel --output-dir dist


### PR DESCRIPTION
Summary:

Following deprecation of the macos-13 github remove image (post: https://github.com/actions/runner-images/issues/13046)

Differential Revision: D88912666


