### PR TITLE
Migrate projectaria_tools to Rerun 0.26.2 API (#327)

### DIFF
--- a/projectaria_tools/utils/rerun_viewer_mps.py
+++ b/projectaria_tools/utils/rerun_viewer_mps.py
@@ -930,8 +930,8 @@ def log_mps_to_rerun(
     # Iterate over the data and LOG data as we see fit
     for data in provider.deliver_queued_sensor_data(deliver_option):
         device_time_ns = data.get_time_ns(TimeDomain.DEVICE_TIME)
-        rr.set_time_nanos("device_time", device_time_ns)
-        rr.set_time_sequence("timestamp", device_time_ns)
+        rr.set_time("device_time", duration=device_time_ns * 1e-9)
+        rr.set_time("timestamp", sequence=device_time_ns)
         progress_bar.update(1)
 
         log_camera_pose(

--- a/projectaria_tools/utils/viewer_aria_sensors.py
+++ b/projectaria_tools/utils/viewer_aria_sensors.py
@@ -68,7 +68,8 @@ def main():
 
     # Run the viewer in the web browser or desktop app
     if args.web:
-        rr.serve_web()
+        _uri = rr.serve_grpc()
+        rr.serve_web_viewer(connect_to=_uri)
     else:
         rr.spawn()
 

--- a/projectaria_tools/utils/viewer_projects_adt.py
+++ b/projectaria_tools/utils/viewer_projects_adt.py
@@ -244,8 +244,8 @@ def main():
     static_obj_ids: Set[int] = set()
     dynamic_obj_moved: Set[str] = set()
     for timestamp_ns in tqdm(img_timestamps_ns):
-        rr.set_time_nanos("device_time", timestamp_ns)
-        rr.set_time_sequence("timestamp", timestamp_ns)
+        rr.set_time("device_time", duration=timestamp_ns * 1e-9)
+        rr.set_time("timestamp", sequence=timestamp_ns)
 
         # Log RGB image
         image_with_dt = gt_provider.get_aria_image_by_timestamp_ns(

--- a/projectaria_tools/utils/viewer_projects_aea.py
+++ b/projectaria_tools/utils/viewer_projects_aea.py
@@ -147,13 +147,13 @@ def logInstanceData(
 ):
     device_time_ns = timestamp_ns
     if time_domain is TimeDomain.TIME_CODE:
-        rr.set_time_nanos("timecode_ns", timestamp_ns)
+        rr.set_time("timecode_ns", duration=timestamp_ns * 1e-9)
 
         device_time_ns = aea_data_provider.vrs.convert_from_timecode_to_device_time_ns(
             timestamp_ns
         )
-    rr.set_time_nanos("device_time_ns", device_time_ns)
-    rr.set_time_sequence("timestamp", device_time_ns)
+    rr.set_time("device_time_ns", duration=device_time_ns * 1e-9)
+    rr.set_time("timestamp", sequence=device_time_ns)
 
     rgb_stream_label = aea_data_provider.vrs.get_label_from_stream_id(RGB_STREAM_ID)
     device_calibration = aea_data_provider.vrs.get_device_calibration()

--- a/projectaria_tools/utils/viewer_projects_ase.py
+++ b/projectaria_tools/utils/viewer_projects_ase.py
@@ -160,8 +160,10 @@ def main():
             trajectory["Ts_world_from_device"],
         )
     ):
-        rr.set_time_nanos("device_time", int(timestamp_ns * 1e3))  # convert to us to ns
-        rr.set_time_sequence("frame_id", frame_id)
+        rr.set_time(
+            "device_time", duration=int(timestamp_ns * 1e3) * 1e-9
+        )  # convert to us to ns
+        rr.set_time("frame_id", sequence=frame_id)
         T_world_from_device = pose  # SE3.from_matrix(pose)
         T_world_camera = T_world_from_device @ T_device_from_camera
         rr.log("world/device", ToTransform3D(T_world_camera, False))

--- a/setup.py
+++ b/setup.py
@@ -158,7 +158,7 @@ def main():
         install_requires=[
             "numpy",
             "requests",  # Required for datasets downloader
-            "rerun-sdk>=0.20.0",
+            "rerun-sdk==0.26.2",
             "tqdm",
         ],
         extras_require={


### PR DESCRIPTION
Summary:


X-link: https://github.com/facebookresearch/projectaria_gen2_pilot_dataset/pull/5

Part of a repo-wide upgrade of the Rerun visualization SDK from 0.22.1 to
0.26.2. Rerun 0.26.2 introduces a unified `rr.set_time()` API, renames
several archetypes to plural forms, and moves from TCP to gRPC transport.

This diff migrates aria_data_plotter.py (the core Aria rerun viewer).

Key API changes applied:
- `rr.set_time_nanos` → `rr.set_time("device_time", timestamp=ns * 1e-9)`
- `rr.TimeNanosColumn` → `rr.TimeColumn("device_time", timestamp=...)`
- `rr.Scalar` → `rr.Scalars`

Reviewed By: YLouWashU

Differential Revision: D94047679
