### PR TITLE
Migrate projectaria_tools to Rerun 0.26.2 API (#327)

### DIFF
--- a/projectaria_tools/tools/aria_rerun_viewer/aria_data_plotter.py
+++ b/projectaria_tools/tools/aria_rerun_viewer/aria_data_plotter.py
@@ -622,7 +622,7 @@ class AriaDataViewer:
                 f"Frame is not a numpy array for label {label}",
             )
             return
-        rr.set_time_nanos("device_time", device_timestamp_ns)
+        rr.set_time("device_time", timestamp=device_timestamp_ns * 1e-9)
         frame = self._check_and_rotate_image_for_gen1(frame, label)
         rr.log(
             label,
@@ -655,34 +655,34 @@ class AriaDataViewer:
         # Log accelerometer data
         rr.send_columns(
             f"{label}/accl/x[m-sec2]",
-            indexes=[rr.TimeNanosColumn("device_time", timestamps)],
+            indexes=[rr.TimeColumn("device_time", timestamp=timestamps * 1e-9)],
             columns=[rr.components.ScalarBatch(accel_data[:, 0])],
         )
         rr.send_columns(
             f"{label}/accl/y[m-sec2]",
-            indexes=[rr.TimeNanosColumn("device_time", timestamps)],
+            indexes=[rr.TimeColumn("device_time", timestamp=timestamps * 1e-9)],
             columns=[rr.components.ScalarBatch(accel_data[:, 1])],
         )
         rr.send_columns(
             f"{label}/accl/z[m-sec2]",
-            indexes=[rr.TimeNanosColumn("device_time", timestamps)],
+            indexes=[rr.TimeColumn("device_time", timestamp=timestamps * 1e-9)],
             columns=[rr.components.ScalarBatch(accel_data[:, 2])],
         )
 
         # Log gyroscope data
         rr.send_columns(
             f"{label}/gyro/x[rad-sec]",
-            indexes=[rr.TimeNanosColumn("device_time", timestamps)],
+            indexes=[rr.TimeColumn("device_time", timestamp=timestamps * 1e-9)],
             columns=[rr.components.ScalarBatch(gyro_data[:, 0])],
         )
         rr.send_columns(
             f"{label}/gyro/y[rad-sec]",
-            indexes=[rr.TimeNanosColumn("device_time", timestamps)],
+            indexes=[rr.TimeColumn("device_time", timestamp=timestamps * 1e-9)],
             columns=[rr.components.ScalarBatch(gyro_data[:, 1])],
         )
         rr.send_columns(
             f"{label}/gyro/z[rad-sec]",
-            indexes=[rr.TimeNanosColumn("device_time", timestamps)],
+            indexes=[rr.TimeColumn("device_time", timestamp=timestamps * 1e-9)],
             columns=[rr.components.ScalarBatch(gyro_data[:, 2])],
         )
 
@@ -701,13 +701,13 @@ class AriaDataViewer:
                 f"IMU data missing required attributes for label {label}",
             )
             return
-        rr.set_time_nanos("device_time", imu_data.capture_timestamp_ns)
-        rr.log(f"{label}/accl/x[m-sec2]", rr.Scalar(imu_data.accel_msec2[0]))
-        rr.log(f"{label}/accl/y[m-sec2]", rr.Scalar(imu_data.accel_msec2[1]))
-        rr.log(f"{label}/accl/z[m-sec2]", rr.Scalar(imu_data.accel_msec2[2]))
-        rr.log(f"{label}/gyro/x[rad-sec]", rr.Scalar(imu_data.gyro_radsec[0]))
-        rr.log(f"{label}/gyro/y[rad-sec]", rr.Scalar(imu_data.gyro_radsec[1]))
-        rr.log(f"{label}/gyro/z[rad-sec]", rr.Scalar(imu_data.gyro_radsec[2]))
+        rr.set_time("device_time", timestamp=imu_data.capture_timestamp_ns * 1e-9)
+        rr.log(f"{label}/accl/x[m-sec2]", rr.Scalars(imu_data.accel_msec2[0]))
+        rr.log(f"{label}/accl/y[m-sec2]", rr.Scalars(imu_data.accel_msec2[1]))
+        rr.log(f"{label}/accl/z[m-sec2]", rr.Scalars(imu_data.accel_msec2[2]))
+        rr.log(f"{label}/gyro/x[rad-sec]", rr.Scalars(imu_data.gyro_radsec[0]))
+        rr.log(f"{label}/gyro/y[rad-sec]", rr.Scalars(imu_data.gyro_radsec[1]))
+        rr.log(f"{label}/gyro/z[rad-sec]", rr.Scalars(imu_data.gyro_radsec[2]))
 
     def plot_magnetometer(self, magnetometer_data):
         """Plot magnetometer sensor data."""
@@ -725,19 +725,21 @@ class AriaDataViewer:
             )
             return
 
-        rr.set_time_nanos("device_time", magnetometer_data.capture_timestamp_ns)
+        rr.set_time(
+            "device_time", timestamp=magnetometer_data.capture_timestamp_ns * 1e-9
+        )
         # Convert magnetometer reading from tesla (SI unit) to microtesla (µT): 1 tesla = 1e6 microtesla
         rr.log(
             f"{self.sensor_labels.magnetometer_label}/x[µT]",
-            rr.Scalar(magnetometer_data.mag_tesla[0] * 1e6),
+            rr.Scalars(magnetometer_data.mag_tesla[0] * 1e6),
         )
         rr.log(
             f"{self.sensor_labels.magnetometer_label}/y[µT]",
-            rr.Scalar(magnetometer_data.mag_tesla[1] * 1e6),
+            rr.Scalars(magnetometer_data.mag_tesla[1] * 1e6),
         )
         rr.log(
             f"{self.sensor_labels.magnetometer_label}/z[µT]",
-            rr.Scalar(magnetometer_data.mag_tesla[2] * 1e6),
+            rr.Scalars(magnetometer_data.mag_tesla[2] * 1e6),
         )
 
     def plot_barometer(self, barometer_data):
@@ -757,15 +759,15 @@ class AriaDataViewer:
                 "Barometer data missing required attributes",
             )
             return
-        rr.set_time_nanos("device_time", barometer_data.capture_timestamp_ns)
+        rr.set_time("device_time", timestamp=barometer_data.capture_timestamp_ns * 1e-9)
         # Convert pressure from pascal (SI unit) to kilopascal (kPa): 1 pascal = 1e-3 kilopascal
         rr.log(
             f"{self.sensor_labels.barometer_labels[0]}/pressure[kPa]",
-            rr.Scalar(barometer_data.pressure * 1e-3),
+            rr.Scalars(barometer_data.pressure * 1e-3),
         )  # Pascals converter to kPascals
         rr.log(
             f"{self.sensor_labels.barometer_labels[1]}/temperature[Celsius]",
-            rr.Scalar(barometer_data.temperature),
+            rr.Scalars(barometer_data.temperature),
         )  # Degree Celsius
 
     def _plot_audio_from_selected_channels(
@@ -804,9 +806,12 @@ class AriaDataViewer:
             rr.send_columns(
                 f"{rerun_plotter_label}/{selected_channel_labels[c]}",
                 indexes=[
-                    rr.TimeNanosColumn(
+                    rr.TimeColumn(
                         "device_time",
-                        audio_data_timestamp[:: self.config.audio_subsample_rate],
+                        timestamp=np.array(audio_data_timestamp)[
+                            :: self.config.audio_subsample_rate
+                        ]
+                        * 1e-9,
                     )
                 ],
                 columns=[
@@ -885,7 +890,7 @@ class AriaDataViewer:
             )
             return
 
-        rr.set_time_nanos("device_time", gps_data.capture_timestamp_ns)
+        rr.set_time("device_time", timestamp=gps_data.capture_timestamp_ns * 1e-9)
         # gps_data.provider is a string that can be "APP" or "GPS", indicating data source.
         gps_settings = self.PLOT_COLORS_AND_SIZES_2D[
             "gps_app"
@@ -912,8 +917,8 @@ class AriaDataViewer:
                 "device_calibration is None. Cannot plot eye gaze data.",
             )
             return
-        rr.set_time_nanos(
-            "device_time", int(eyegaze_data.tracking_timestamp.total_seconds() * 1e9)
+        rr.set_time(
+            "device_time", timestamp=eyegaze_data.tracking_timestamp.total_seconds()
         )
         # Clear the canvas (only if eye_gaze_label exists for this device version)
         if self.sensor_labels.eye_gaze_label:
@@ -1013,7 +1018,7 @@ class AriaDataViewer:
         device_timestamp_ns = image_data[1].capture_timestamp_ns
         camera_label = "camera-fixation-crop"
 
-        rr.set_time_nanos("device_time", device_timestamp_ns)
+        rr.set_time("device_time", timestamp=device_timestamp_ns * 1e-9)
 
         frame = np.array(image_array)
         rr.log(
@@ -1045,7 +1050,7 @@ class AriaDataViewer:
         device_timestamp_ns = image_record.capture_timestamp_ns
         camera_label = "camera-cropped-pov"
 
-        rr.set_time_nanos("device_time", device_timestamp_ns)
+        rr.set_time("device_time", timestamp=device_timestamp_ns * 1e-9)
 
         frame = np.array(image_array)
         rr.log(
@@ -1167,8 +1172,8 @@ class AriaDataViewer:
         """
         Plot hand pose data in 3D world view
         """
-        rr.set_time_nanos(
-            "device_time", int(hand_pose_data.tracking_timestamp.total_seconds() * 1e9)
+        rr.set_time(
+            "device_time", timestamp=hand_pose_data.tracking_timestamp.total_seconds()
         )
 
         # Clear the canvas (only if hand_tracking_label exists for this device version)
@@ -1211,9 +1216,9 @@ class AriaDataViewer:
             return
 
         if self.sensor_labels.hand_tracking_label:
-            rr.set_time_nanos(
+            rr.set_time(
                 "device_time",
-                int(hand_pose_data.tracking_timestamp.total_seconds() * 1e9),
+                timestamp=hand_pose_data.tracking_timestamp.total_seconds(),
             )
 
             # Clear the canvas first
@@ -1241,9 +1246,9 @@ class AriaDataViewer:
                 "device_calibration is None. Cannot plot VIO high frequency data.",
             )
             return
-        rr.set_time_nanos(
+        rr.set_time(
             "device_time",
-            int(vio_high_freq_data.tracking_timestamp.total_seconds() * 1e9),
+            timestamp=vio_high_freq_data.tracking_timestamp.total_seconds(),
         )
         # Set and plot Aria Device for the current timestamp
         T_World_Device = vio_high_freq_data.transform_odometry_device
@@ -1270,7 +1275,7 @@ class AriaDataViewer:
             or vio_data.pose_quality != TrackingQuality.GOOD
         ):
             return
-        rr.set_time_nanos("device_time", vio_data.capture_timestamp_ns)
+        rr.set_time("device_time", timestamp=vio_data.capture_timestamp_ns * 1e-9)
         # Set and plot Aria Device for the current timestamp
         T_World_Device = (
             vio_data.transform_odometry_bodyimu @ vio_data.transform_bodyimu_device
@@ -1327,7 +1332,7 @@ class AriaDataViewer:
     def plot_utc_timestamp(
         self, utc_timestamp_ns, camera_label: str, device_timestamp_ns
     ):
-        rr.set_time_nanos("device_time", device_timestamp_ns)
+        rr.set_time("device_time", timestamp=device_timestamp_ns * 1e-9)
         rr.log(
             f"{camera_label}/utc_timestamp",
             rr.Points2D(

--- a/projectaria_tools/tools/viewer_mps/rerun_viewer_mps.py
+++ b/projectaria_tools/tools/viewer_mps/rerun_viewer_mps.py
@@ -917,8 +917,8 @@ def log_mps_to_rerun(
     # Iterate over the data and LOG data as we see fit
     for data in provider.deliver_queued_sensor_data(deliver_option):
         device_time_ns = data.get_time_ns(TimeDomain.DEVICE_TIME)
-        rr.set_time_nanos("device_time", device_time_ns)
-        rr.set_time_sequence("timestamp", device_time_ns)
+        rr.set_time("device_time", duration=device_time_ns * 1e-9)
+        rr.set_time("timestamp", sequence=device_time_ns)
         progress_bar.update(1)
 
         log_camera_pose(

--- a/projectaria_tools/tools/viewer_projects/viewer_projects_adt.py
+++ b/projectaria_tools/tools/viewer_projects/viewer_projects_adt.py
@@ -244,8 +244,8 @@ def main():
     static_obj_ids: Set[int] = set()
     dynamic_obj_moved: Set[str] = set()
     for timestamp_ns in tqdm(img_timestamps_ns):
-        rr.set_time_nanos("device_time", timestamp_ns)
-        rr.set_time_sequence("timestamp", timestamp_ns)
+        rr.set_time("device_time", duration=timestamp_ns * 1e-9)
+        rr.set_time("timestamp", sequence=timestamp_ns)
 
         # Log RGB image
         image_with_dt = gt_provider.get_aria_image_by_timestamp_ns(

--- a/projectaria_tools/tools/viewer_projects/viewer_projects_aea.py
+++ b/projectaria_tools/tools/viewer_projects/viewer_projects_aea.py
@@ -147,13 +147,13 @@ def logInstanceData(
 ):
     device_time_ns = timestamp_ns
     if time_domain is TimeDomain.TIME_CODE:
-        rr.set_time_nanos("timecode_ns", timestamp_ns)
+        rr.set_time("timecode_ns", duration=timestamp_ns * 1e-9)
 
         device_time_ns = aea_data_provider.vrs.convert_from_timecode_to_device_time_ns(
             timestamp_ns
         )
-    rr.set_time_nanos("device_time_ns", device_time_ns)
-    rr.set_time_sequence("timestamp", device_time_ns)
+    rr.set_time("device_time_ns", duration=device_time_ns * 1e-9)
+    rr.set_time("timestamp", sequence=device_time_ns)
 
     rgb_stream_label = aea_data_provider.vrs.get_label_from_stream_id(RGB_STREAM_ID)
     device_calibration = aea_data_provider.vrs.get_device_calibration()

--- a/projectaria_tools/tools/viewer_projects/viewer_projects_ase.py
+++ b/projectaria_tools/tools/viewer_projects/viewer_projects_ase.py
@@ -160,8 +160,10 @@ def main():
             trajectory["Ts_world_from_device"],
         )
     ):
-        rr.set_time_nanos("device_time", int(timestamp_ns * 1e3))  # convert to us to ns
-        rr.set_time_sequence("frame_id", frame_id)
+        rr.set_time(
+            "device_time", duration=int(timestamp_ns * 1e3) * 1e-9
+        )  # convert to us to ns
+        rr.set_time("frame_id", sequence=frame_id)
         T_world_from_device = pose  # SE3.from_matrix(pose)
         T_world_camera = T_world_from_device @ T_device_from_camera
         rr.log("world/device", ToTransform3D(T_world_camera, False))

--- a/setup.py
+++ b/setup.py
@@ -158,7 +158,7 @@ def main():
         install_requires=[
             "numpy",
             "requests",  # Required for datasets downloader
-            "rerun-sdk==0.22.1",
+            "rerun-sdk==0.26.2",
             "tqdm",
         ],
         extras_require={
@@ -170,7 +170,7 @@ def main():
                 "pillow",
                 "plotly",
                 "scipy",
-                "rerun-notebook==0.22.1",
+                "rerun-notebook==0.26.2",
                 ## Required for vrs_to_mp4
                 "moviepy==1.0.3",
             ]


### PR DESCRIPTION
Summary:


X-link: https://github.com/facebookresearch/projectaria_gen2_pilot_dataset/pull/5

Part of a repo-wide upgrade of the Rerun visualization SDK from 0.22.1 to
0.26.2. Rerun 0.26.2 introduces a unified `rr.set_time()` API, renames
several archetypes to plural forms, and moves from TCP to gRPC transport.

This diff migrates aria_data_plotter.py (the core Aria rerun viewer).

Key API changes applied:
- `rr.set_time_nanos` → `rr.set_time("device_time", timestamp=ns * 1e-9)`
- `rr.TimeNanosColumn` → `rr.TimeColumn("device_time", timestamp=...)`
- `rr.Scalar` → `rr.Scalars`

Reviewed By: YLouWashU

Differential Revision: D94047679
