### PR TITLE
{Build} Core - Bump VRS dependency to include ProximitySensorRecordableClass (#338)

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04,  macos-14] # macos-14 is macSilicon
+        os: [ubuntu-latest, macos-14] # macos-14 is macSilicon
     steps:
       - name : Checkout
         uses: actions/checkout@v4
@@ -39,7 +39,7 @@ jobs:
               sudo apt-get install -o Acquire::Retries=5 \
                 libgtest-dev libgmock-dev \
                 libfmt-dev \
-                libturbojpeg-dev libpng-dev \
+                libjpeg-dev libturbojpeg-dev libpng-dev \
                 liblz4-dev libzstd-dev libxxhash-dev \
                 libboost-date-time-dev \
                 libboost-filesystem-dev \

--- a/.github/workflows/build-and-test_projects.yml
+++ b/.github/workflows/build-and-test_projects.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-14]  # macos-14 is macSilicon
+        os: [ubuntu-latest, macos-14]  # macos-14 is macSilicon
         project: [
           PROJECTARIA_TOOLS_BUILD_PROJECTS_ADT,
           PROJECTARIA_TOOLS_BUILD_TOOLS]
@@ -41,7 +41,7 @@ jobs:
               # Install VRS dependencies
               sudo apt-get install -o Acquire::Retries=5 \
                 libfmt-dev \
-                libturbojpeg-dev libpng-dev \
+                libjpeg-dev libturbojpeg-dev libpng-dev \
                 liblz4-dev libzstd-dev libxxhash-dev \
                 libboost-date-time-dev \
                 libboost-filesystem-dev \

--- a/.github/workflows/build-wheels-and-deploy.yml
+++ b/.github/workflows/build-wheels-and-deploy.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   build-stubs:
     name: Build Python stubs
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -46,7 +46,7 @@ jobs:
             sudo apt-get install -o Acquire::Retries=5 \
               libgtest-dev libgmock-dev \
               libfmt-dev \
-              libturbojpeg-dev libpng-dev \
+              libjpeg-dev libturbojpeg-dev libpng-dev \
               liblz4-dev libzstd-dev libxxhash-dev \
               libboost-date-time-dev \
               libboost-filesystem-dev \
@@ -80,7 +80,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, ubuntu-22.04] # macos-14 is macSilicon
+        os: [macos-14, ubuntu-latest] # macos-14 is macSilicon
         python-version: ["3.10", "3.11", "3.12"]
         # Default consider only Python >=3.10 since actions/setup-python supports only python<3.10 and mac-silicon
         # Other Python versions are added below as matrix entries
@@ -91,8 +91,8 @@ jobs:
             cibw_build: "cp311-*"
           - python-version: "3.12"
             cibw_build: "cp312-*"
-          # Add matrix entries: Python 3.9 to ubuntu-22.04
-          - os: ubuntu-22.04
+          # Add matrix entries: Python 3.9 to ubuntu-latest
+          - os: ubuntu-latest
             python-version: "3.9"
             cibw_build: "cp39-*"
 
@@ -116,7 +116,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install cibuildwheel==2.17.0
       - name: Install ffmpeg dependency lib
-        if: ${{ (matrix.os == 'macos-14') || (matrix.os == 'ubuntu-22.04') }}
+        if: ${{ (matrix.os == 'macos-14') || (matrix.os == 'ubuntu-latest') }}
         shell: bash
         run: |
           ./build_third_party_libs/build_ffmpeg_linuxunix.sh
@@ -131,7 +131,7 @@ jobs:
           CIBW_SKIP: "*-manylinux_i686 *-musllinux_* *x86_64*"
           CIBW_ARCHS: "arm64"
       - name: Build wheels for CPython
-        if: ${{ matrix.os == 'ubuntu-22.04' }}
+        if: ${{ matrix.os == 'ubuntu-latest' }}
         shell: bash
         run: |
           CMAKE_BUILD_PARALLEL_LEVEL=4 python -m cibuildwheel --output-dir dist

--- a/.github/workflows/test-for-build-wheels.yml
+++ b/.github/workflows/test-for-build-wheels.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build-stubs:
     name: Build Python stubs
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -35,7 +35,7 @@ jobs:
             sudo apt-get install -o Acquire::Retries=5 \
               libgtest-dev libgmock-dev \
               libfmt-dev \
-              libturbojpeg-dev libpng-dev \
+              libjpeg-dev libturbojpeg-dev libpng-dev \
               liblz4-dev libzstd-dev libxxhash-dev \
               libboost-date-time-dev \
               libboost-filesystem-dev \
@@ -69,7 +69,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, ubuntu-22.04] # macos-14 is macSilicon
+        os: [macos-14, ubuntu-latest] # macos-14 is macSilicon
         python-version: ["3.10", "3.11", "3.12"]
         # Default consider only Python >=3.10 since actions/setup-python supports only python<3.10 and mac-silicon
         # Other Python versions are added below as matrix entries
@@ -81,10 +81,10 @@ jobs:
           - python-version: "3.12"
             cibw_build: "cp312-*"
           # Add matrix entries: Python ["3.8", "3.9"] to [ubuntu-latest]
-          - os: ubuntu-22.04
+          - os: ubuntu-latest
             python-version: "3.8"
             cibw_build: "cp38-*"
-          - os: ubuntu-22.04
+          - os: ubuntu-latest
             python-version: "3.9"
             cibw_build: "cp39-*"
 
@@ -107,7 +107,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install cibuildwheel==2.17.0
       - name: Install ffmpeg dependency lib
-        if: ${{ (matrix.os == 'macos-14') || (matrix.os == 'ubuntu-22.04') }}
+        if: ${{ (matrix.os == 'macos-14') || (matrix.os == 'ubuntu-latest') }}
         shell: bash
         run: |
           ./build_third_party_libs/build_ffmpeg_linuxunix.sh
@@ -122,7 +122,7 @@ jobs:
           CIBW_SKIP: "*-manylinux_i686 *-musllinux_* *x86_64*"
           CIBW_ARCHS: "arm64"
       - name: Build wheels for CPython
-        if: ${{ (matrix.os == 'ubuntu-22.04') }}
+        if: ${{ (matrix.os == 'ubuntu-latest') }}
         shell: bash
         run: |
           CMAKE_BUILD_PARALLEL_LEVEL=4 python -m cibuildwheel --output-dir dist

--- a/cmake/Setup3rdParty.cmake
+++ b/cmake/Setup3rdParty.cmake
@@ -40,7 +40,7 @@ FetchContent_Declare(
 FetchContent_Declare(
   vrs
   GIT_REPOSITORY https://github.com/facebookresearch/vrs.git
-  GIT_TAG 29c585dcb9c4192a06e9d94a614b88731499381d # master Sept 15, 2025.
+  GIT_TAG fff58fc32493552260449a7435c580aa4ae27451 # main Apr 21, 2026.
 )
 # Override config for vrs
 option(UNIT_TESTS OFF)


### PR DESCRIPTION
Summary:

The OSS VRS dependency was pinned to Sept 2025, which predates the addition of ProximitySensorRecordableClass (added Dec 2025). This causes CMake builds that depend on this enum (e.g. VRS Health Check) to fail. Bump VRS to latest main which includes this and other new RecordableTypeId values.

Differential Revision: D101880345


