### PR TITLE
{Feature} Core - Add random-access P-frame decoding support in ImageSensorPlayer

### DIFF
--- a/core/data_provider/players/ImageSensorPlayer.cpp
+++ b/core/data_provider/players/ImageSensorPlayer.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <atomic>
 #include <cmath>
 #include <optional>
 
@@ -24,6 +25,26 @@
 #include <vrs/RecordFormat.h>
 
 namespace projectaria::tools::data_provider {
+
+namespace {
+// See ImageSensorPlayer.h for the invariants these counters pin.
+std::atomic<int> gReadMissingFramesCallCount{0};
+std::atomic<int> gInvokeCallbackCount{0};
+} // namespace
+
+int ImageSensorPlayer::getReadMissingFramesCallCount() {
+  return gReadMissingFramesCallCount.load(std::memory_order_relaxed);
+}
+
+int ImageSensorPlayer::getInvokeCallbackCount() {
+  return gInvokeCallbackCount.load(std::memory_order_relaxed);
+}
+
+void ImageSensorPlayer::resetDebugCounters() {
+  gReadMissingFramesCallCount.store(0, std::memory_order_relaxed);
+  gInvokeCallbackCount.store(0, std::memory_order_relaxed);
+}
+
 std::optional<projectaria::tools::image::ImageVariant> ImageData::imageVariant() const {
   if (pixelFrame->getSpec().getImageFormat() == vrs::ImageFormat::JPG) {
     std::shared_ptr<vrs::utils::PixelFrame> normalizedFrame;
@@ -126,10 +147,15 @@ bool ImageSensorPlayer::onImageRead(
     success = handleNormalImageProcessing(r, cb, imageSpec);
   }
 
-  if (success) {
-    invokeCallbackAndCache();
-  } else {
+  if (!success) {
     return false;
+  }
+  // During a P-frame replay walk (triggered from recordReadComplete), let data_/dataRecord_
+  // update naturally so the final replayed record (the user-visible target frame) leaves them
+  // in the correct state, but suppress the user callback and dedup cache update — those fire
+  // exactly once for the target from recordReadComplete().
+  if (!whileReadingMissingFrames()) {
+    invokeCallbackAndCache();
   }
 
   if (verbose_) {
@@ -205,6 +231,21 @@ bool ImageSensorPlayer::handleYuv420Processing(
 void ImageSensorPlayer::invokeCallbackAndCache() {
   callback_(data_, dataRecord_, configRecord_, verbose_);
   cachedCaptureTimestampNs_ = dataRecord_.captureTimestampNs;
+  gInvokeCallbackCount.fetch_add(1, std::memory_order_relaxed);
+}
+
+int ImageSensorPlayer::recordReadComplete(
+    vrs::RecordFileReader& fileReader,
+    const vrs::IndexRecord::RecordInfo& recordInfo) {
+  if (!getVideoFrameHandler(streamId_).isMissingFrames()) {
+    return 0;
+  }
+  gReadMissingFramesCallCount.fetch_add(1, std::memory_order_relaxed);
+  int result = readMissingFrames(fileReader, recordInfo, /*exactFrame=*/true);
+  if (result == 0 && data_.isValid()) {
+    invokeCallbackAndCache();
+  }
+  return result;
 }
 
 } // namespace projectaria::tools::data_provider

--- a/core/data_provider/players/ImageSensorPlayer.h
+++ b/core/data_provider/players/ImageSensorPlayer.h
@@ -157,11 +157,34 @@ class ImageSensorPlayer : public vrs::utils::VideoRecordFormatStreamPlayer {
     emptyFrameMode_ = emptyFrameMode;
   }
 
+  // Test-only debug counters used to pin two invariants of the random-access
+  // P-frame fix without taking on a friend declaration in VRS's
+  // VideoFrameHandler (see Lessons L4):
+  //  - readMissingFramesCallCount: how many times recordReadComplete actually
+  //    invoked readMissingFrames. A linear sweep should bump this at most once,
+  //    proving the forward-step optimization stays O(1) per frame.
+  //  - invokeCallbackCount: how many times the user ImageCallback fired. A
+  //    single getImageDataByIndex call must bump this exactly once even when
+  //    the target sits N P-frames into a GOP and triggers an N-record replay.
+  // These are static so tests can read them without holding a player instance
+  // (players live inside VrsDataProvider). The atomic increments are
+  // unconditional but cheap; they do not depend on NDEBUG.
+  static int getReadMissingFramesCallCount();
+  static int getInvokeCallbackCount();
+  static void resetDebugCounters();
+
  private:
   bool onDataLayoutRead(const vrs::CurrentRecord& r, size_t blockIndex, vrs::DataLayout& dl)
       override;
   bool onImageRead(const vrs::CurrentRecord& r, size_t /*idx*/, const vrs::ContentBlock& cb)
       override;
+  // Random-access P-frame fix. When a mid-GOP read sets isMissingFrames(), walk back to the
+  // keyframe and replay until the target frame is decoded. Reference implementation lives behind
+  // #if 0 in arvr/libraries/vrs/vrs/utils/VideoRecordFormatStreamPlayer.h:87-95; if VRS ever
+  // enables it upstream this override becomes a trivial delete.
+  int recordReadComplete(
+      vrs::RecordFileReader& fileReader,
+      const vrs::IndexRecord::RecordInfo& recordInfo) override;
 
   // Helper methods for different image processing modes
   bool handleEmptyFrameMode(const vrs::ContentBlock& cb);


### PR DESCRIPTION
Summary:
Adds random-access support for P-frame video streams in VrsDataProvider.

Previously, getImageDataByIndex() only worked correctly for sequential reads or I-frames. Reading a mid-GOP P-frame out of order returned incorrect pixels because the decoder's DPB (Decoded Picture Buffer) lacked the required reference frames.

This adds a recordReadComplete() override in ImageSensorPlayer that detects isMissingFrames() and walks back to the preceding keyframe via readMissingFrames(), then replays through the target frame. The user callback fires exactly once per getImageDataByIndex() call, even when the replay decodes multiple intermediate frames.

Enables random-access video frame retrieval for training data pipelines, video editors, and any workflow that needs non-sequential frame access.

Differential Revision: D101928539


