### PR TITLE
{Continuous Integration} Test Wheel Build - Update cibuildwheel to 2.21.0 and drop EOL Python versions

### DIFF
--- a/.github/workflows/test-for-build-wheels.yml
+++ b/.github/workflows/test-for-build-wheels.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Upgrade pip and python packages
         run: |
           python -m pip install --upgrade pip
-          python -m pip install cibuildwheel==2.17.0 pybind11-stubgen==1.1
+          python -m pip install cibuildwheel==2.21.0 pybind11-stubgen==1.1
       - name: Install dependencies
         shell: bash
         run: |
@@ -71,22 +71,13 @@ jobs:
       matrix:
         os: [macos-14, ubuntu-latest] # macos-14 is macSilicon
         python-version: ["3.10", "3.11", "3.12"]
-        # Default consider only Python >=3.10 since actions/setup-python supports only python<3.10 and mac-silicon
-        # Other Python versions are added below as matrix entries
-        include: # Customize cibuildwheel python version to build
+        include:
           - python-version: "3.10"
             cibw_build: "cp310-*"
           - python-version: "3.11"
             cibw_build: "cp311-*"
           - python-version: "3.12"
             cibw_build: "cp312-*"
-          # Add matrix entries: Python ["3.8", "3.9"] to [ubuntu-latest]
-          - os: ubuntu-latest
-            python-version: "3.8"
-            cibw_build: "cp38-*"
-          - os: ubuntu-latest
-            python-version: "3.9"
-            cibw_build: "cp39-*"
 
     steps:
       - name: Checkout repo
@@ -105,7 +96,7 @@ jobs:
       - name: Upgrade pip and python packages
         run: |
           python -m pip install --upgrade pip
-          python -m pip install cibuildwheel==2.17.0
+          python -m pip install cibuildwheel==2.21.0
       - name: Install ffmpeg dependency lib
         if: ${{ (matrix.os == 'macos-14') || (matrix.os == 'ubuntu-latest') }}
         shell: bash
@@ -121,6 +112,7 @@ jobs:
           CIBW_BUILD: ${{ matrix.cibw_build }}
           CIBW_SKIP: "*-manylinux_i686 *-musllinux_* *x86_64*"
           CIBW_ARCHS: "arm64"
+          CIBW_ENVIRONMENT_MACOS: "MACOSX_DEPLOYMENT_TARGET=14.0"
       - name: Build wheels for CPython
         if: ${{ (matrix.os == 'ubuntu-latest') }}
         shell: bash


### PR DESCRIPTION
Summary:
Explanation:
Sets up the test wheel build workflow as a release-readiness canary. A follow-up diff will add a weekly schedule trigger so this workflow runs automatically each Monday — the goal is to detect cibuildwheel/delocate/runner-image drift before it blocks a release. For that signal to be useful, this diff first updates the workflow to a forward-compatible cibuildwheel + delocate environment; without this preparation, scheduling the existing pinned 2-year-old environment would re-run the same frozen build every Monday and detect no drift.

Brings cibuildwheel from 2.17.0 (pinned in 2024 due to a macOS dylib delocation issue) to 2.21.0, and sets MACOSX_DEPLOYMENT_TARGET=14.0 to satisfy the strict wheel-tag check in delocate 0.12.0 (a transitive dependency that newer cibuildwheel pulls). Drops Python 3.8 and 3.9 matrix entries -- they are EOL and no longer supported by GitHub runner images. This is the same recipe applied to projectaria_private_libs.

Note: this changes the macOS install floor for wheels built by this canary to macOS 14 (Sonoma) and later. macOS 11/12/13 are no longer testable on GitHub Actions (macos-13 runners deprecated late 2025), so this matches the testable surface.

Reproducibility:
Triggered the workflow manually via workflow_dispatch after the change; all 6 matrix cells (macos-14 + ubuntu-latest x Python 3.10/3.11/3.12) built and tested wheels successfully. Inspected wheel filenames to confirm the manylinux tag did not shift unexpectedly.

Differential Revision: D104881993


