### PR TITLE
{Continuous Integration} Test Wheel Build - Restore Python 3.9 ubuntu matrix entry to mirror publish workflow (#350)

### DIFF
--- a/.github/workflows/test-for-build-wheels.yml
+++ b/.github/workflows/test-for-build-wheels.yml
@@ -78,6 +78,10 @@ jobs:
             cibw_build: "cp311-*"
           - python-version: "3.12"
             cibw_build: "cp312-*"
+          # Add Python 3.9 to ubuntu-latest
+          - os: ubuntu-latest
+            python-version: "3.9"
+            cibw_build: "cp39-*"
 
     steps:
       - name: Checkout repo


### PR DESCRIPTION
Summary:

Explanation:
The previous canary recipe diff dropped Python 3.9 from the test-for-build-wheels matrix, but the publish workflow (build-wheels-and-deploy.yml) still ships a cp39 Linux wheel on every release. Without 3.9 in the canary, a future cibuildwheel/runner-image change that breaks 3.9 wheel builds would only be detected on release day.

Restores the Python 3.9 ubuntu-latest entry so the canary matrix mirrors the publish matrix exactly: macOS 14 x {3.10, 3.11, 3.12} + ubuntu-latest x {3.9, 3.10, 3.11, 3.12} = 7 cells.

Reproducibility:
N/A -- matrix-only change. The 3.9 wheel will build with the existing CIBW_BUILD: cp39-* pattern that was previously in this file.

Differential Revision: D104899027


