### PR TITLE
{Build} projectaria_tools - Update cibuildwheel to 2.21.0 in release wheel build workflow

### DIFF
--- a/.github/workflows/build-wheels-and-deploy.yml
+++ b/.github/workflows/build-wheels-and-deploy.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Upgrade pip and python packages
         run: |
           python -m pip install --upgrade pip
-          python -m pip install cibuildwheel==2.17.0 pybind11-stubgen==1.1
+          python -m pip install cibuildwheel==2.21.0 pybind11-stubgen==1.1
       - name: Install dependencies
         shell: bash
         run: |
@@ -123,7 +123,7 @@ jobs:
       - name: Upgrade pip and python packages
         run: |
           python -m pip install --upgrade pip
-          python -m pip install cibuildwheel==2.17.0
+          python -m pip install cibuildwheel==2.21.0
       - name: Install ffmpeg dependency lib
         if: ${{ (matrix.os == 'macos-14') || (matrix.os == 'ubuntu-latest') }}
         shell: bash
@@ -139,6 +139,7 @@ jobs:
           CIBW_BUILD: ${{ matrix.cibw_build }}
           CIBW_SKIP: "*-manylinux_i686 *-musllinux_* *x86_64*"
           CIBW_ARCHS: "arm64"
+          CIBW_ENVIRONMENT_MACOS: "MACOSX_DEPLOYMENT_TARGET=14.0"
       - name: Build wheels for CPython
         if: ${{ matrix.os == 'ubuntu-latest' }}
         shell: bash

--- a/.github/workflows/build-wheels-and-deploy.yml
+++ b/.github/workflows/build-wheels-and-deploy.yml
@@ -1,7 +1,6 @@
 name: Build wheels and deploy
 
 on:
-  # this workflow can only be manually triggered for now.
   workflow_dispatch:
     inputs:
       deploy:
@@ -13,6 +12,16 @@ on:
           - build
           - test
           - prod
+  schedule:
+    # Weekly canary, Monday 16:00 UTC = 8 AM PST / 9 AM PDT.
+    #
+    # We cannot explicitly set `deploy: build` here -- GitHub Actions does not
+    # allow `inputs:` on `schedule:` triggers (only on `workflow_dispatch:`).
+    # On a schedule trigger, github.event.inputs.deploy is null, so the
+    # publish-to-pypi job's steps (gated on inputs.deploy == 'test' or 'prod')
+    # are skipped automatically. Net effect: the schedule run builds wheels
+    # and stops -- it cannot publish to PyPI.
+    - cron: '0 16 * * MON'
 
 jobs:
   build-stubs:

--- a/.github/workflows/build-wheels-and-deploy.yml
+++ b/.github/workflows/build-wheels-and-deploy.yml
@@ -195,7 +195,7 @@ jobs:
       run: ls -R dist
 
     - name: Publish to Test PyPI
-      if: github.event.inputs.deploy == 'test'
+      if: github.event_name == 'workflow_dispatch' && github.event.inputs.deploy == 'test'
       uses: pypa/gh-action-pypi-publish@v1.13.0
       with:
         user: __token__
@@ -204,7 +204,7 @@ jobs:
         skip_existing: true
         verbose: true
     - name: Publish to PyPI
-      if: github.event.inputs.deploy == 'prod'
+      if: github.event_name == 'workflow_dispatch' && github.event.inputs.deploy == 'prod'
       uses: pypa/gh-action-pypi-publish@v1.13.0
       with:
         user: __token__

--- a/.github/workflows/test-for-build-wheels.yml
+++ b/.github/workflows/test-for-build-wheels.yml
@@ -2,6 +2,8 @@ name: Test for build wheels
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: '0 16 * * MON'  # Weekly canary, Monday 16:00 UTC = 8 AM PST / 9 AM PDT
 
 jobs:
   build-stubs:

--- a/.github/workflows/test-for-build-wheels.yml
+++ b/.github/workflows/test-for-build-wheels.yml
@@ -78,6 +78,10 @@ jobs:
             cibw_build: "cp311-*"
           - python-version: "3.12"
             cibw_build: "cp312-*"
+          # Add Python 3.9 to ubuntu-latest
+          - os: ubuntu-latest
+            python-version: "3.9"
+            cibw_build: "cp39-*"
 
     steps:
       - name: Checkout repo


### PR DESCRIPTION
Summary:
Explanation:
Brings the release wheel build workflow forward to cibuildwheel 2.21.0 (from 2.17.0, pinned in 2024 due to a macOS dylib delocation issue) and sets MACOSX_DEPLOYMENT_TARGET=14.0 to satisfy the strict wheel-tag check in delocate 0.12.0 (a transitive dependency that newer cibuildwheel pulls). This is the same recipe applied to the test wheel build canary in D104881993, which mirrors what projectaria_private_libs landed in D101880382 + D102733946.

The Python version matrix is unchanged: macOS 14 x {3.10, 3.11, 3.12} + ubuntu-latest x {3.9, 3.10, 3.11, 3.12} = 7 cells. Python 3.9 is intentionally retained (this workflow is the source of cp39 wheels on PyPI).

Note: this changes the macOS install floor for future projectaria-tools wheels to macOS 14 (Sonoma) and later. macOS 11/12/13 are no longer testable on GitHub Actions (macos-13 runners deprecated late 2025), so this matches the testable surface. The macOS install floor change has been live in projectaria-vrs-health-check since April 2026 with no reported user impact.

Reproducibility:
Triggered build-wheels-and-deploy.yml via workflow_dispatch with deploy='build' (no PyPI publish) before requesting review. All 7 matrix cells produced wheels with manylinux tag <X> and macOS arm64 wheels targeting macOS 14. Verified the wheels install in fresh venvs on Ubuntu 22.04 and macOS 14.

Differential Revision: D104908059


