### PR TITLE
ci: declare workflow-level `contents: read` on 4 workflows

### DIFF
--- a/.github/workflows/build-and-test-pixi.yml
+++ b/.github/workflows/build-and-test-pixi.yml
@@ -10,6 +10,9 @@ on:
     paths-ignore:
       - "**/website/**"
 
+permissions:
+  contents: read
+
 jobs:
   run_c:
     name: C++ - Build/Test - ${{ matrix.os }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,6 +10,9 @@ on:
     paths-ignore:
       - "**/website/**"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build projectaria_tools on ${{ matrix.os }}

--- a/.github/workflows/build-and-test_projects.yml
+++ b/.github/workflows/build-and-test_projects.yml
@@ -10,6 +10,9 @@ on:
     paths-ignore:
       - "**/website/**"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build ${{ matrix.project }} on ${{ matrix.os }}

--- a/.github/workflows/test-for-build-wheels.yml
+++ b/.github/workflows/test-for-build-wheels.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: '0 16 * * MON'  # Weekly canary, Monday 16:00 UTC = 8 AM PST / 9 AM PDT
 
+permissions:
+  contents: read
+
 jobs:
   build-stubs:
     name: Build Python stubs


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on 4 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.