### PR TITLE
fix(mps): make bisection_timestamp_search return the truly closest index

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -100,6 +100,7 @@ jobs:
           export TEST_FOLDER_GEN2="./data/gen2/"
           python3 -m unittest core/python/test/corePyBindTest.py
           python3 -m unittest core/python/test/mpsPyBindTest.py
+          python3 -m unittest core/python/test/mpsUtilsTest.py
           python3 -m unittest core/python/sophus/test/sophusPybindTest.py
 
       - name: Test Python Notebooks

--- a/core/python/test/mpsUtilsTest.py
+++ b/core/python/test/mpsUtilsTest.py
@@ -36,6 +36,12 @@ class BisectionTimestampSearchTest(unittest.TestCase):
         # Tie-break is deterministic toward the lower index.
         self.assertEqual(bisection_timestamp_search(self.ts, 6000), 2)
 
+    def test_exact_match_on_first_or_last_returns_its_index(self) -> None:
+        # The border guards used <= / >=, so an exact match on the first or
+        # last timestamp returned None instead of its index.
+        self.assertEqual(bisection_timestamp_search(self.ts, 1000), 0)
+        self.assertEqual(bisection_timestamp_search(self.ts, 19000), 9)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/core/python/test/mpsUtilsTest.py
+++ b/core/python/test/mpsUtilsTest.py
@@ -1,0 +1,41 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from datetime import timedelta
+from types import SimpleNamespace
+
+from projectaria_tools.core.mps.utils import bisection_timestamp_search
+
+
+def _make(ns_values):
+    # timedelta has microsecond resolution; use multiples of 1000 ns for exact round-trip.
+    return [SimpleNamespace(tracking_timestamp=timedelta(microseconds=v / 1000)) for v in ns_values]
+
+
+class BisectionTimestampSearchTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.ts = _make([1000, 3000, 5000, 7000, 9000, 11000, 13000, 15000, 17000, 19000])
+
+    def test_returns_truly_closest_neighbor(self) -> None:
+        # Regression for #100: query 14900 is closer to 15000 (index 7) than to 13000 (index 6).
+        self.assertEqual(bisection_timestamp_search(self.ts, 14900), 7)
+
+    def test_equidistant_prefers_lower_index(self) -> None:
+        # Tie-break is deterministic toward the lower index.
+        self.assertEqual(bisection_timestamp_search(self.ts, 6000), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/projectaria_tools/core/mps/utils.py
+++ b/projectaria_tools/core/mps/utils.py
@@ -52,7 +52,29 @@ def bisection_timestamp_search(timed_data, query_timestamp_ns: int) -> int:
             start = mid + 1
         else:
             end = mid - 1
-    return start
+    # The loop can leave `start` on either side of the query, so check both
+    # neighbors and keep the closest one. Ties go to the lower index.
+    best = start
+    best_dist = abs(
+        timed_data[best].tracking_timestamp.total_seconds() * 1e9
+        - query_timestamp_ns
+    )
+    if start > 0:
+        prev_dist = abs(
+            timed_data[start - 1].tracking_timestamp.total_seconds() * 1e9
+            - query_timestamp_ns
+        )
+        if prev_dist <= best_dist:
+            best = start - 1
+            best_dist = prev_dist
+    if start + 1 < len(timed_data):
+        next_dist = abs(
+            timed_data[start + 1].tracking_timestamp.total_seconds() * 1e9
+            - query_timestamp_ns
+        )
+        if next_dist < best_dist:
+            best = start + 1
+    return best
 
 
 def get_nearest_eye_gaze(eye_gazes: List[EyeGaze], query_timestamp_ns: int) -> EyeGaze:

--- a/projectaria_tools/core/mps/utils.py
+++ b/projectaria_tools/core/mps/utils.py
@@ -36,9 +36,9 @@ def bisection_timestamp_search(timed_data, query_timestamp_ns: int) -> int:
     if timed_data and len(timed_data) > 1:
         first_timestamp = timed_data[0].tracking_timestamp.total_seconds() * 1e9
         last_timestamp = timed_data[-1].tracking_timestamp.total_seconds() * 1e9
-        if query_timestamp_ns <= first_timestamp:
+        if query_timestamp_ns < first_timestamp:
             return None
-        elif query_timestamp_ns >= last_timestamp:
+        elif query_timestamp_ns > last_timestamp:
             return None
     # If this is safe we perform the Bisection search
     start = 0


### PR DESCRIPTION
Closes #100.

`bisection_timestamp_search` was supposed to return the closest timestamp but it returned whichever side the binary search happened to land on. With `[1000, 3000, ..., 19000]` and query 14900, it returned index 6 (distance 1900) instead of 7 (distance 100). All four `get_nearest_*` wrappers advertise "closest or equal" in their docstrings, so they were silently returning the wrong neighbor for any query that fell between samples.

Credit to @georgegu1997 for the analysis in the issue thread.

Structured as two commits in case the second one feels out of scope.

Commit 1 keeps the existing border guards and binary search loop untouched. After the loop converges, the new code compares the three candidate indices (`start - 1`, `start`, `start + 1`) by absolute distance and returns the closest one. Ties break toward the lower index.

Commit 2 is a separate but related bug that fell out of the same review. The original border guards used `<=` and `>=`, so querying the exact first or last timestamp returned None instead of index 0 or len-1. Tightened to `<` and `>`. Happy to drop this commit if you'd rather see it as its own PR.

Added 3 unittests in `core/python/test/mpsUtilsTest.py` (same naming and style as `mpsPyBindTest.py`), wired into `build-and-test.yml`. On main all three fail (the #100 regression, the tie-break, and the endpoint case). On commit 1 alone the endpoint case still fails. On the full PR they all pass. The tests use `SimpleNamespace` to stub the `tracking_timestamp` attribute so they run without `pip install .`; CI still does the full install so the real import path is exercised.

All four internal callsites of `bisection_timestamp_search` just do `data[bisection_index]` after a None check; none depend on the old "always less or equal" behavior.