### PR TITLE
{Build} Visualization - Migrate Rerun SDK to 0.33

### DIFF
--- a/tools/samples/python/mps_semidense_point_visibility/mps_semidense_point_visibility_demo.py
+++ b/tools/samples/python/mps_semidense_point_visibility/mps_semidense_point_visibility_demo.py
@@ -15,6 +15,7 @@
 import os
 from typing import Dict, List
 
+import numpy as np
 import rerun as rr
 import rerun.blueprint as rrb
 from PointsAndObservationsManager import (
@@ -224,7 +225,7 @@ frame_set_uids: Dict[str, List[int]] = {}
 #
 for data in tqdm(vrs_data_provider.deliver_queued_sensor_data(deliver_option)):
     device_time_ns = data.get_time_ns(TimeDomain.DEVICE_TIME)
-    rr.set_time_nanos("device_time", device_time_ns)
+    rr.set_time("device_time", duration=np.timedelta64(device_time_ns, "ns"))
 
     # Display device pose
     closed_loop_pose = mps_data_provider.get_closed_loop_pose(device_time_ns)


### PR DESCRIPTION
Summary:
Migrate projectaria_tools (project_aria) Rerun logging to rerun-sdk 0.33.

API migrations:
- Update axis_length on the ToTransform3D -> use rr.TransformAxes3D(axis_length=...)

Bug Fix:
- When using --rrd_output_path, the viewer was spawn and not enabling to log to disk
- Use the blueprint to set the default timeline to device_time -- it was defaulting to timestamp and not enabling to play the video at framerate

Differential Revision: D112244313


