### PR TITLE
{Build} Core - Bump VRS pin for XPRS NVDEC symbols (#383)

### DIFF
--- a/cmake/Setup3rdParty.cmake
+++ b/cmake/Setup3rdParty.cmake
@@ -40,7 +40,7 @@ FetchContent_Declare(
 FetchContent_Declare(
   vrs
   GIT_REPOSITORY https://github.com/facebookresearch/vrs.git
-  GIT_TAG 125db715b73e2768723defcb88ccb755fabcd43d # main Jun 26, 2026.
+  GIT_TAG 2f4fc9e555311928bc4643ea251a1542216f5e74 # main Aug 3rd, 2026.
 )
 # Override config for vrs
 option(UNIT_TESTS OFF)


### PR DESCRIPTION
Summary:

Explanation:
`projectaria_tools` builds VRS via `FetchContent` with a pinned `GIT_TAG` in
`cmake/Setup3rdParty.cmake`. The previous pin (`125db715`, main Jun 26, 2026)
predates the XPRS NVDEC changes, so `core/python/XprsPyBind.h` references
`xprs::hasCudaSupport` while the fetched VRS does not declare it. The external
wheel build fails with:

```
core/python/XprsPyBind.h:152:14: error: no member named 'hasCudaSupport' in namespace 'xprs'
      &xprs::hasCudaSupport,
```

This bumps the VRS pin to `2f4fc9e555311928bc4643ea251a1542216f5e74`, which
carries the NVDEC symbols (`xprs::hasCudaSupport` plus the `ENABLE_NVCODEC`
plumbing), unblocking NVDEC in the wheel build.

Reproducibility:
The pinned commit resolves in `facebookresearch/vrs`, so `FetchContent` can
fetch it and the wheel build can compile `XprsPyBind.h`. The cibuildwheel jobs
on the child diffs exercise the resulting wheel.

Reviewed By: kongchen1992

Differential Revision: D114445000


