### PR TITLE
{BugFix} Core - Wire NeuralBand calibration libs into OSS CMake build

### DIFF
--- a/core/calibration/CMakeLists.txt
+++ b/core/calibration/CMakeLists.txt
@@ -38,15 +38,26 @@ target_include_directories(camera_config_builder PUBLIC "../")
 target_link_libraries(camera_config_builder PUBLIC device_version PRIVATE config_file_loader vrs_logging nlohmann_json::nlohmann_json)
 
 
+add_library(neural_band_emg_calibration
+    NeuralBandEmgCalibration.cpp NeuralBandEmgCalibration.h)
+target_include_directories(neural_band_emg_calibration PUBLIC "../")
+target_link_libraries(neural_band_emg_calibration PRIVATE nlohmann_json::nlohmann_json)
+
+add_library(neural_band_imu_calibration
+    NeuralBandImuCalibration.cpp NeuralBandImuCalibration.h)
+target_include_directories(neural_band_imu_calibration PUBLIC "../")
+target_link_libraries(neural_band_imu_calibration PUBLIC Eigen3::Eigen PRIVATE nlohmann_json::nlohmann_json)
+
 add_library(sensor_calibration
     SensorCalibration.cpp SensorCalibration.h
     CameraCalibration.cpp CameraCalibration.h CameraCalibrationFormat.h
     ImuMagnetometerCalibration.cpp ImuMagnetometerCalibration.h ImuMagnetometerCalibrationFormat.h
     BarometerCalibration.cpp BarometerCalibration.h
     MicrophoneCalibration.cpp MicrophoneCalibration.h
+    NeuralBandBatchCalibration.h
 )
 target_include_directories(sensor_calibration PUBLIC "../")
-target_link_libraries(sensor_calibration PUBLIC format error_handler camera_projection vrs_logging calibration_distort camera_config_builder)
+target_link_libraries(sensor_calibration PUBLIC format error_handler camera_projection vrs_logging calibration_distort camera_config_builder neural_band_emg_calibration neural_band_imu_calibration)
 
 add_library(svd_point_cloud_alignment SvdPointCloudAlignment.cpp SvdPointCloudAlignment.h)
 target_include_directories(svd_point_cloud_alignment PUBLIC "../")

--- a/core/data_provider/players/CMakeLists.txt
+++ b/core/data_provider/players/CMakeLists.txt
@@ -34,6 +34,8 @@ target_link_libraries(players
   Sophus::Sophus
   image
   hand_tracking
+  neural_band_emg_calibration
+  neural_band_imu_calibration
   INTERFACE
   data_layout
   PRIVATE


### PR DESCRIPTION
Summary:
Explanation:
D114276637 added `NeuralBandEmgCalibration`, `NeuralBandImuCalibration`,
and the `NeuralBandBatchCalibration` wrapper under `core/calibration/`
and consumed them from `NeuralBandBatchPlayer.cpp`, but only wired the
new sources through BUCK. The OSS CMake build was never updated, so the
GitHub Actions `build-and-test.yml` and `test-for-build-wheels.yml`
workflows fail at link time with 4 undefined references
(`NeuralBandEmgCalibration::fromParamsJson`,
`NeuralBandImuCalibration::fromParamsJson`,
`NeuralBandImuCalibration::getAccelScalingFactor`,
`NeuralBandImuCalibration::getGyroScalingFactor`) coming from
`libplayers.a(NeuralBandBatchPlayer.cpp.o)`.

This mirrors the BUCK targets in CMake:

- `core/calibration/CMakeLists.txt`: add `neural_band_emg_calibration`
  and `neural_band_imu_calibration` libraries (matching the BUCK
  `oxx_static_library` targets), add `NeuralBandBatchCalibration.h` to
  `sensor_calibration`'s header list, and link both new libs from
  `sensor_calibration` `PUBLIC` (so downstream users of
  `SensorCalibration.h` get the wrapper header + symbols).
- `core/data_provider/players/CMakeLists.txt`: link
  `neural_band_emg_calibration` and `neural_band_imu_calibration` from
  `players` `PUBLIC`, matching the `public_deps` on the players BUCK
  target.

Reproducibility:
GitHub Actions `build-and-test.yml` and `test-for-build-wheels.yml`
will pass on the next ShipIt export. Local BUCK build is unaffected.

___

Differential Revision: D114627185


