### PR TITLE
{Feature} CUDA Decoding - Install nv-codec-headers in manylinux wheel build

### DIFF
--- a/build_third_party_libs/install_manylinux_deps.sh
+++ b/build_third_party_libs/install_manylinux_deps.sh
@@ -54,6 +54,13 @@ cd /tmp && curl -kOL http://downloads.xiph.org/releases/opus/opus-1.5.2.tar.gz \
   && make install \
   && rm -rf /tmp/opus-1.5.2.tar.gz /tmp/opus-1.5.2 \
 
+# Build nv-codec-headers (header-only) so XPRS can be built with NVDEC GPU
+# H.265 decode. No CUDA toolkit is needed at build time; the driver's
+# libcuda/libnvcuvid are dlopen'd at runtime, keeping the wheel CUDA-agnostic.
+cd /tmp && git clone --depth 1 --branch n12.1.14.0 https://github.com/FFmpeg/nv-codec-headers.git \
+  && make -C nv-codec-headers install PREFIX=/usr \
+  && rm -rf /tmp/nv-codec-headers;
+
 # Build FFmpeg
 cd /project \
   && ./build_third_party_libs/build_ffmpeg_linuxunix.sh

--- a/cmake/Setup3rdParty.cmake
+++ b/cmake/Setup3rdParty.cmake
@@ -40,7 +40,7 @@ FetchContent_Declare(
 FetchContent_Declare(
   vrs
   GIT_REPOSITORY https://github.com/facebookresearch/vrs.git
-  GIT_TAG 125db715b73e2768723defcb88ccb755fabcd43d # main Jun 26, 2026.
+  GIT_TAG 2f4fc9e555311928bc4643ea251a1542216f5e74 # main Aug 3rd, 2026. VRS is updated with CUDA-acceleration support.
 )
 # Override config for vrs
 option(UNIT_TESTS OFF)


### PR DESCRIPTION
Summary:
The cibuildwheel Linux build runs inside a manylinux container (`CIBW_BEFORE_BUILD_LINUX` -> `install_manylinux_deps.sh`). To build the `projectaria_tools` wheel with NVDEC GPU H.265 decode enabled, that container needs `nv-codec-headers` (provides the `ffnvcodec` pkg-config the XPRS NVDEC build links against). This adds a header-only clone+install of `nv-codec-headers` (tag `n12.1.14.0`, matching the internal Video Codec SDK) before the FFmpeg build. No CUDA toolkit is required at build time; the driver's `libcuda`/`libnvcuvid` are dlopen'd at runtime, so the wheel stays CUDA-agnostic.

Prerequisite for enabling `PROJECTARIA_ENABLE_CUDA` in the cibuildwheel workflow (next diff in this stack).

Reviewed By: kongchen1992

Differential Revision: D114393581


