### PR TITLE
{Feature} CUDA Decoding - Enable NVDEC in cibuildwheel and harden wheel test

### DIFF
--- a/.github/workflows/build-wheels-and-deploy.yml
+++ b/.github/workflows/build-wheels-and-deploy.yml
@@ -149,6 +149,13 @@ jobs:
           CIBW_BUILD_VERBOSITY: 3
           CIBW_BUILD: ${{ matrix.cibw_build }}
           CIBW_BEFORE_BUILD_LINUX: bash build_third_party_libs/install_manylinux_deps.sh
+          # Enable NVDEC GPU H.265 decode in Linux x86_64 wheels. The build needs
+          # only nv-codec-headers (installed by install_manylinux_deps.sh), not a
+          # GPU or CUDA toolkit; the wheel stays CUDA-agnostic.
+          CIBW_ENVIRONMENT_LINUX: "PROJECTARIA_ENABLE_CUDA=1"
+          # libcuda/libnvcuvid are dlopen'd from the driver at runtime and must
+          # never be vendored into the wheel; exclude them from auditwheel repair.
+          CIBW_REPAIR_WHEEL_COMMAND_LINUX: "auditwheel repair --exclude libcuda.so.1 --exclude libnvcuvid.so.1 -w {dest_dir} {wheel}"
           CIBW_SKIP: "*-manylinux_i686 *-musllinux_*"
           CIBW_ARCHS: "x86_64"
       - name: Build wheels for CPython
@@ -176,6 +183,19 @@ jobs:
           export TEST_FOLDER_GEN2="./data/gen2/"
           python -m unittest core/python/test/corePyBindTest.py
           python -m unittest core/python/test/mpsPyBindTest.py
+          # CUDA-agnostic checks. Runners have no GPU, so has_cuda_support() is
+          # expected to return False here; the point is that it runs without a
+          # CUDA install, and the Linux wheel links no CUDA libraries (they are
+          # dlopen'd from the driver at runtime, never bundled).
+          python -c "import projectaria_tools as t; print('has_cuda_support:', t.has_cuda_support())"
+          if [ "$RUNNER_OS" == "Linux" ]; then
+            CORE_SO=$(python -c "import _core_pybinds; print(_core_pybinds.__file__)")
+            echo "Checking $CORE_SO for CUDA linkage"
+            if readelf -d "$CORE_SO" | grep NEEDED | grep -iE 'libcuda|libnvcuvid'; then
+              echo "ERROR: wheel links CUDA libraries; it must be CUDA-agnostic" && exit 1
+            fi
+            echo "OK: no CUDA libraries in NEEDED"
+          fi
 
   publish-to-pypi:
     name: Publish to Pypi

--- a/.github/workflows/test-for-build-wheels.yml
+++ b/.github/workflows/test-for-build-wheels.yml
@@ -131,6 +131,13 @@ jobs:
           CIBW_BUILD_VERBOSITY: 3
           CIBW_BUILD: ${{ matrix.cibw_build }}
           CIBW_BEFORE_BUILD_LINUX: bash build_third_party_libs/install_manylinux_deps.sh
+          # Enable NVDEC GPU H.265 decode in Linux x86_64 wheels. The build needs
+          # only nv-codec-headers (installed by install_manylinux_deps.sh), not a
+          # GPU or CUDA toolkit; the wheel stays CUDA-agnostic.
+          CIBW_ENVIRONMENT_LINUX: "PROJECTARIA_ENABLE_CUDA=1"
+          # libcuda/libnvcuvid are dlopen'd from the driver at runtime and must
+          # never be vendored into the wheel; exclude them from auditwheel repair.
+          CIBW_REPAIR_WHEEL_COMMAND_LINUX: "auditwheel repair --exclude libcuda.so.1 --exclude libnvcuvid.so.1 -w {dest_dir} {wheel}"
           CIBW_SKIP: "*-manylinux_i686 *-musllinux_*"
           CIBW_ARCHS: "x86_64"
       - name: Build wheels for CPython
@@ -158,3 +165,16 @@ jobs:
           export TEST_FOLDER_GEN2="./data/gen2/"
           python -m unittest core/python/test/corePyBindTest.py
           python -m unittest core/python/test/mpsPyBindTest.py
+          # CUDA-agnostic checks. Runners have no GPU, so has_cuda_support() is
+          # expected to return False here; the point is that it runs without a
+          # CUDA install, and the Linux wheel links no CUDA libraries (they are
+          # dlopen'd from the driver at runtime, never bundled).
+          python -c "import projectaria_tools as t; print('has_cuda_support:', t.has_cuda_support())"
+          if [ "$RUNNER_OS" == "Linux" ]; then
+            CORE_SO=$(python -c "import _core_pybinds; print(_core_pybinds.__file__)")
+            echo "Checking $CORE_SO for CUDA linkage"
+            if readelf -d "$CORE_SO" | grep NEEDED | grep -iE 'libcuda|libnvcuvid'; then
+              echo "ERROR: wheel links CUDA libraries; it must be CUDA-agnostic" && exit 1
+            fi
+            echo "OK: no CUDA libraries in NEEDED"
+          fi

--- a/build_third_party_libs/install_manylinux_deps.sh
+++ b/build_third_party_libs/install_manylinux_deps.sh
@@ -54,6 +54,13 @@ cd /tmp && curl -kOL http://downloads.xiph.org/releases/opus/opus-1.5.2.tar.gz \
   && make install \
   && rm -rf /tmp/opus-1.5.2.tar.gz /tmp/opus-1.5.2 \
 
+# Build nv-codec-headers (header-only) so XPRS can be built with NVDEC GPU
+# H.265 decode. No CUDA toolkit is needed at build time; the driver's
+# libcuda/libnvcuvid are dlopen'd at runtime, keeping the wheel CUDA-agnostic.
+cd /tmp && git clone --depth 1 --branch n12.1.14.0 https://github.com/FFmpeg/nv-codec-headers.git \
+  && make -C nv-codec-headers install PREFIX=/usr \
+  && rm -rf /tmp/nv-codec-headers;
+
 # Build FFmpeg
 cd /project \
   && ./build_third_party_libs/build_ffmpeg_linuxunix.sh


### PR DESCRIPTION
Summary:
Builds the Linux x86_64 `projectaria_tools` wheels with NVDEC GPU H.265 decode enabled, and hardens the in-CI wheel test to lock in the CUDA-agnostic guarantee. Applied to both `build-wheels-and-deploy.yml` and `test-for-build-wheels.yml`:
- ubuntu cibuildwheel step: `CIBW_ENVIRONMENT_LINUX="PROJECTARIA_ENABLE_CUDA=1"` (turns on `-DENABLE_NVCODEC=ON` via `setup.py`; the build needs only `nv-codec-headers` installed by the prior diff, no GPU or CUDA toolkit). macOS wheels are unaffected -- NVDEC is Linux-only.
- `CIBW_REPAIR_WHEEL_COMMAND_LINUX` adds `auditwheel repair --exclude libcuda.so.1 --exclude libnvcuvid.so.1` so the driver libs are never vendored into the wheel (they are dlopen'd at runtime).
- Test wheel step: runs `has_cuda_support()` (returns False on the no-GPU runner) and, on Linux, asserts the built `_core_pybinds` extension has no `libcuda`/`libnvcuvid` in `DT_NEEDED`.

GPU decode itself cannot be exercised in CI (GitHub runners have no NVIDIA GPU); it is validated manually on a GPU machine against the CI-built / TestPyPI wheel (shipping plan Stage 3.5 / 4).

Reviewed By: kongchen1992

Differential Revision: D114393583


